### PR TITLE
feat: add shared booking url fallback

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,8 @@ import { useMemo, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { Calculator, CheckCircle2, ChevronDown, Mail, Phone } from 'lucide-react'
 
+import { bookingUrl } from '@/lib/booking'
+
 function trackPlausible(name:string, props?:Record<string,any>){ if (typeof window!=='undefined' && (window as any).plausible){ (window as any).plausible(name, { props }); } }
 
 export default function Page(){
@@ -33,7 +35,7 @@ function Hero(){
           </p>
           <div className="mt-6 flex gap-3">
             <a href="#pricing" className="rounded-full bg-[color:var(--primary)] text-slate-900 px-5 py-3">View Packages</a>
-            <a data-book-call onClick={()=>trackPlausible('BookCallClick')} href="#contact" className="rounded-full border px-5 py-3">Book a call</a>
+            <a data-book-call onClick={()=>trackPlausible('BookCallClick')} href={bookingUrl} className="rounded-full border px-5 py-3">Book a call</a>
           </div>
         </div>
         <div className="card">
@@ -78,7 +80,7 @@ function Pricing(){
               <li className="flex items-center gap-2"><CheckCircle2 size={16}/> Findings & backlog</li>
               <li className="flex items-center gap-2"><CheckCircle2 size={16}/> 30-day support</li>
             </ul>
-            <a data-book-call onClick={()=>trackPlausible('BookCallClick')} href="#contact" className="mt-4 inline-block rounded-full bg-[color:var(--primary)] text-slate-900 px-4 py-2">Book</a>
+            <a data-book-call onClick={()=>trackPlausible('BookCallClick')} href={bookingUrl} className="mt-4 inline-block rounded-full bg-[color:var(--primary)] text-slate-900 px-4 py-2">Book</a>
           </div>
         ))}
       </div>
@@ -207,7 +209,7 @@ function CTA(){
         <p className="text-slate-300 mt-2">Tell us about your goals. We’ll respond within one business day.</p>
         <div className="mt-6 flex flex-col md:flex-row gap-3 justify-center">
           <a className="rounded-full bg-[color:var(--primary)] text-slate-900 px-5 py-3 inline-flex items-center gap-2" href="mailto:hello@icarius-consulting.com"><Mail size={18}/> Email us</a>
-          <a data-book-call onClick={()=>trackPlausible('BookCallClick')} className="rounded-full border px-5 py-3 inline-flex items-center gap-2" href="#"><Phone size={18}/> Book a call</a>
+          <a data-book-call onClick={()=>trackPlausible('BookCallClick')} className="rounded-full border px-5 py-3 inline-flex items-center gap-2" href={bookingUrl}><Phone size={18}/> Book a call</a>
         </div>
       </div>
     </section>

--- a/components/consent-provider.tsx
+++ b/components/consent-provider.tsx
@@ -15,6 +15,9 @@ export function ConsentProvider({ children }: { children: React.ReactNode }) {
       const target = e.target as HTMLElement
       const trigger = target?.closest?.('[data-book-call]')
       if (trigger) {
+        if (e.metaKey || e.ctrlKey || e.button !== 0) {
+          return
+        }
         e.preventDefault()
         ;(window as any).plausible?.('BookCallClick')
         document.getElementById('calendly')?.setAttribute('aria-hidden', 'false')

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -2,6 +2,8 @@
 import Image from 'next/image'
 import { useEffect, useRef, useState } from 'react'
 
+import { bookingUrl } from '@/lib/booking'
+
 function trackPlausible(name:string, props?:Record<string,any>){ if (typeof window!=='undefined' && (window as any).plausible){ (window as any).plausible(name, { props }); } }
 
 // Utility for trapping focus within a modal
@@ -59,6 +61,11 @@ export function Header(){
     const handleBookCallClick = (e: Event) => {
       const target = e.target as HTMLElement
       if (target && target.closest('[data-book-call]')) {
+        if (e instanceof MouseEvent) {
+          if (e.metaKey || e.ctrlKey || e.button !== 0) {
+            return
+          }
+        }
         e.preventDefault()
         trackPlausible('BookCallClick')
         const calendly = document.getElementById('calendly')
@@ -107,13 +114,13 @@ export function Header(){
           <a href="#work" className="hover:underline">Work</a>
           <a href="#pricing" className="hover:underline">Packages</a>
           <a href="#contact" className="hover:underline">Contact</a>
-          <button
-            type="button"
+          <a
             data-book-call
+            href={bookingUrl}
             className="inline-flex items-center gap-2 rounded-full border px-4 py-2"
           >
             Book a call
-          </button>
+          </a>
         </nav>
       </div>
     </header>

--- a/lib/booking.ts
+++ b/lib/booking.ts
@@ -1,0 +1,1 @@
+export const bookingUrl = process.env.NEXT_PUBLIC_CALENDLY_URL ?? 'https://calendly.com/icarius/intro-call'


### PR DESCRIPTION
## Summary
- add a shared booking URL helper so CTAs can fall back to the public Calendly page
- update the header and on-page call-to-action links to use the shared URL while retaining modal tracking
- allow modifier clicks on booking CTAs to open the Calendly page while normal clicks continue to launch the modal

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df08af5e248330ad532f403615ee63