### PR TITLE
Configure clean URLs and marketing redirects for Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,6 @@
 {
+  "cleanUrls": true,
+  "trailingSlash": false,
   "headers": [
     {
       "source": "/(.*)",
@@ -11,10 +13,20 @@
     }
   ],
   "redirects": [
-    { "source": "/services", "destination": "/#services", "permanent": true },
-    { "source": "/work", "destination": "/#work", "permanent": true },
-    { "source": "/pricing", "destination": "/#pricing", "permanent": true },
-    { "source": "/contact", "destination": "/#contact", "permanent": true },
+    { "source": "/index.html", "destination": "/index", "permanent": true },
+    { "source": "/about.html", "destination": "/about", "permanent": true },
+    { "source": "/services.html", "destination": "/services", "permanent": true },
+    { "source": "/work.html", "destination": "/work", "permanent": true },
+    { "source": "/packages.html", "destination": "/packages", "permanent": true },
+    { "source": "/contact.html", "destination": "/contact", "permanent": true },
     { "source": "/insights", "destination": "/blog", "permanent": true }
+  ],
+  "rewrites": [
+    { "source": "/index", "destination": "/index" },
+    { "source": "/about", "destination": "/about" },
+    { "source": "/services", "destination": "/services" },
+    { "source": "/work", "destination": "/work" },
+    { "source": "/packages", "destination": "/packages" },
+    { "source": "/contact", "destination": "/contact" }
   ]
 }


### PR DESCRIPTION
## Summary
- enable clean URL handling and disable trailing slashes in `vercel.json`
- replace hash-anchor redirects with .html-to-clean-path redirects and add rewrites for marketing pages
- retain existing security headers and keep the insights redirect to the blog

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df125e111483309b73c541286d5c4f