### PR TITLE
Switch navigation to dedicated pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'About Icarius Consulting',
+  description:
+    'Learn about the team, ethos, and operating principles behind Icarius Consulting.',
+}
+
+export default function AboutPage() {
+  return (
+    <section className="py-16">
+      <div className="container mx-auto max-w-3xl px-4">
+        <div className="space-y-6">
+          <h1 className="text-4xl font-semibold tracking-tight">About Icarius Consulting</h1>
+          <p className="text-lg text-slate-300">
+            Icarius Consulting partners with finance and operations leaders who need a pragmatic
+            guide through complex transformation. We blend enterprise experience with the agility of a
+            boutique firm, helping clients modernise processes without losing momentum.
+          </p>
+          <p className="text-slate-300">
+            Our team has implemented global back-office platforms, optimised service delivery models,
+            and steered change programmes in highly regulated industries. Every engagement pairs
+            strategic thinking with hands-on delivery support so initiatives launch quickly and land
+            successfully.
+          </p>
+          <p className="text-slate-300">
+            We operate as an embedded partner, collaborating directly with your team, technology
+            stack, and stakeholders. That proximity lets us uncover the friction that slows teams down
+            and design interventions that stick. The result is measurable improvement, faster decision
+            cycles, and a calmer path to scale.
+          </p>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from 'next'
+import { bookingUrl } from '@/lib/booking'
+
+export const metadata: Metadata = {
+  title: 'Contact — Icarius Consulting',
+  description: 'Book time with the Icarius team or request more information about our services.',
+}
+
+const contactMethods = [
+  {
+    label: 'Book an intro call',
+    href: bookingUrl,
+    description: 'Schedule a 30-minute call to discuss your goals and whether we are the right fit.',
+    newTab: true,
+  },
+  {
+    label: 'Email the team',
+    href: 'mailto:hello@icarius-consulting.com',
+    description: 'Share context, RFPs, or supporting information and we will reply within one business day.',
+    newTab: false,
+  },
+]
+
+export default function ContactPage() {
+  return (
+    <section className="py-16">
+      <div className="container mx-auto max-w-3xl px-4">
+        <div className="space-y-6">
+          <header className="space-y-4">
+            <h1 className="text-4xl font-semibold tracking-tight">Contact</h1>
+            <p className="text-lg text-slate-300">
+              We would love to learn about the challenges in front of you. Choose the option below that
+              suits you best and we will respond quickly.
+            </p>
+          </header>
+          <ul className="space-y-4">
+            {contactMethods.map((method) => (
+              <li key={method.label} className="rounded-2xl border border-slate-800 bg-slate-950/40 p-6">
+                <h2 className="text-xl font-semibold text-white">{method.label}</h2>
+                <p className="mt-2 text-sm text-slate-300">{method.description}</p>
+                <a
+                  href={method.href}
+                  className="mt-4 inline-flex text-sm font-medium text-[color:var(--primary)]"
+                  target={method.newTab ? '_blank' : undefined}
+                  rel={method.newTab ? 'noreferrer' : undefined}
+                >
+                  {method.label} →
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/packages/page.tsx
+++ b/app/packages/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Packages — Icarius Consulting',
+  description: 'Choose the engagement model that fits your operational goals and pace.',
+}
+
+const packages = [
+  {
+    name: 'Diagnostic sprint',
+    summary:
+      'A three-week assessment that surfaces quick wins, risks, and a prioritised roadmap for change.',
+  },
+  {
+    name: 'Transformation partner',
+    summary:
+      'Embedded leadership across delivery squads to guide major platform or process rollouts.',
+  },
+  {
+    name: 'Fractional operator',
+    summary:
+      'Part-time executive support to keep initiatives moving while you hire permanent leadership.',
+  },
+]
+
+export default function PackagesPage() {
+  return (
+    <section className="py-16">
+      <div className="container mx-auto max-w-4xl px-4">
+        <div className="space-y-10">
+          <header className="space-y-4">
+            <h1 className="text-4xl font-semibold tracking-tight">Packages</h1>
+            <p className="text-lg text-slate-300">
+              These outlines show how we typically partner with clients. Every package can be adjusted
+              to match your stage, geography, and team structure.
+            </p>
+          </header>
+          <div className="grid gap-6 md:grid-cols-3">
+            {packages.map((offer) => (
+              <article
+                key={offer.name}
+                className="flex h-full flex-col rounded-2xl border border-slate-800 bg-slate-950/40 p-6"
+              >
+                <h2 className="text-2xl font-semibold text-white">{offer.name}</h2>
+                <p className="mt-4 text-sm text-slate-300">{offer.summary}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Services — Icarius Consulting',
+  description:
+    'Explore the consulting services Icarius offers to modernise operations and finance teams.',
+}
+
+const services = [
+  {
+    title: 'Operating model design',
+    description:
+      'Align roles, systems, and processes around the outcomes that matter most so teams can scale',
+  },
+  {
+    title: 'Platform implementation leadership',
+    description:
+      'Navigate ERP, HRIS, or billing deployments with a partner who has led global rollouts before.',
+  },
+  {
+    title: 'Process optimisation sprints',
+    description:
+      'Identify waste, codify best practices, and automate the manual steps that slow delivery.',
+  },
+  {
+    title: 'Fractional operations support',
+    description:
+      'Bridge leadership gaps or accelerate change with an embedded, outcomes-focused operator.',
+  },
+]
+
+export default function ServicesPage() {
+  return (
+    <section className="py-16">
+      <div className="container mx-auto max-w-4xl px-4">
+        <div className="space-y-10">
+          <header className="space-y-4">
+            <h1 className="text-4xl font-semibold tracking-tight">Services</h1>
+            <p className="text-lg text-slate-300">
+              Each engagement is tailored to your stage of growth, but the pillars below outline how
+              we typically help founders and operators remove operational friction.
+            </p>
+          </header>
+          <dl className="grid gap-8 md:grid-cols-2">
+            {services.map((service) => (
+              <div key={service.title} className="rounded-xl border border-slate-800 bg-slate-950/40 p-6">
+                <dt className="text-xl font-medium text-white">{service.title}</dt>
+                <dd className="mt-3 text-sm text-slate-300">{service.description}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Work — Icarius Consulting',
+  description: 'See examples of the outcomes we help operations and finance teams deliver.',
+}
+
+const highlights = [
+  {
+    client: 'Global hospitality scale-up',
+    result:
+      'Integrated finance and workforce management systems across 12 countries, reducing manual reporting time by 45%.',
+  },
+  {
+    client: 'Enterprise payroll provider',
+    result:
+      'Redesigned onboarding workflow and knowledge base, cutting time-to-value for new clients from weeks to days.',
+  },
+  {
+    client: 'AI-enabled professional services firm',
+    result:
+      'Mapped the delivery lifecycle and introduced QA checkpoints that doubled customer satisfaction scores.',
+  },
+]
+
+export default function WorkPage() {
+  return (
+    <section className="py-16">
+      <div className="container mx-auto max-w-4xl px-4">
+        <div className="space-y-10">
+          <header className="space-y-4">
+            <h1 className="text-4xl font-semibold tracking-tight">Our work</h1>
+            <p className="text-lg text-slate-300">
+              We specialise in engagements that blend operational rigour with the empathy required to
+              steer change. Here are a few recent examples of the results our clients achieved.
+            </p>
+          </header>
+          <ul className="space-y-6">
+            {highlights.map((item) => (
+              <li key={item.client} className="rounded-2xl border border-slate-800 bg-slate-950/40 p-6">
+                <h2 className="text-xl font-semibold text-white">{item.client}</h2>
+                <p className="mt-3 text-sm text-slate-300">{item.result}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -98,7 +98,7 @@ export function Header(){
   return (
     <header className={`sticky top-0 z-40 transition-colors border-b ${solid ? 'backdrop-blur bg-[rgba(11,16,32,.7)]' : 'bg-transparent'}`}>
       <div className="container mx-auto flex items-center justify-between py-3 px-4">
-        <a href="#top" className="flex items-center gap-3 font-bold leading-none">
+        <Link href="/" className="flex items-center gap-3 font-bold leading-none">
           {/* Bigger logo using Next.js Image */}
           <Image
             src="/icarius-logo.svg"
@@ -110,7 +110,7 @@ export function Header(){
           />
           {/* Larger brand name */}
           <span className="text-xl md:text-2xl tracking-tight">Icarius Consulting</span>
-        </a>       
+        </Link>
         <nav className="hidden md:flex items-center gap-6 text-sm">
           {primaryNavLinks.map((link) => (
             <Link key={link.href} href={link.href} className="hover:underline">

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -4,11 +4,12 @@ export type NavLink = {
 }
 
 export const primaryNavLinks: NavLink[] = [
-  { href: '#services', label: 'Services' },
-  { href: '#work', label: 'Work' },
-  { href: '#pricing', label: 'Packages' },
+  { href: '/about', label: 'About' },
+  { href: '/services', label: 'Services' },
+  { href: '/work', label: 'Work' },
+  { href: '/packages', label: 'Packages' },
   { href: '/blog', label: 'Insights' },
-  { href: '#contact', label: 'Contact' },
+  { href: '/contact', label: 'Contact' },
 ]
 
 export const footerNavLinks: NavLink[] = [


### PR DESCRIPTION
## Summary
- update the shared navigation config and header to link to full pages instead of hash anchors
- add placeholder top-level pages for about, services, work, packages, and contact so new links resolve

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df12d25d888330a5aa436fa0256a06