### PR TITLE
Create BookCTA component for booking links

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -12,12 +12,16 @@ const contactMethods = [
     href: bookingUrl,
     description: 'Schedule a 30-minute call to discuss your goals and whether we are the right fit.',
     newTab: true,
+    cta: 'contact-page',
+    plan: 'general',
   },
   {
     label: 'Email the team',
     href: 'mailto:hello@icarius-consulting.com',
     description: 'Share context, RFPs, or supporting information and we will reply within one business day.',
     newTab: false,
+    cta: 'contact-page-email',
+    plan: 'general',
   },
 ]
 
@@ -42,7 +46,9 @@ export default function ContactPage() {
                   href={method.href}
                   className="mt-4 inline-flex text-sm font-medium text-[color:var(--primary)]"
                   target={method.newTab ? '_blank' : undefined}
-                  rel={method.newTab ? 'noreferrer' : undefined}
+                  rel={method.newTab ? 'noreferrer noopener' : undefined}
+                  data-cta={method.cta}
+                  data-plan={method.plan}
                 >
                   {method.label} →
                 </a>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,9 +3,7 @@ import { useMemo, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { Calculator, CheckCircle2, ChevronDown, Mail, Phone } from 'lucide-react'
 
-import { bookingUrl } from '@/lib/booking'
-
-function trackPlausible(name:string, props?:Record<string,any>){ if (typeof window!=='undefined' && (window as any).plausible){ (window as any).plausible(name, { props }); } }
+import { BookCTA } from '@/components/BookCTA'
 
 export default function Page(){
   return (
@@ -35,7 +33,9 @@ function Hero(){
           </p>
           <div className="mt-6 flex gap-3">
             <a href="#pricing" className="rounded-full bg-[color:var(--primary)] text-slate-900 px-5 py-3">View Packages</a>
-            <a data-book-call onClick={()=>trackPlausible('BookCallClick')} href={bookingUrl} className="rounded-full border px-5 py-3">Book a call</a>
+            <BookCTA cta="hero" className="rounded-full border px-5 py-3">
+              Book a call
+            </BookCTA>
           </div>
         </div>
         <div className="card">
@@ -63,9 +63,9 @@ function Services(){
 
 function Pricing(){
   const cards = [
-    { name: 'Audit Sprint', price: 6000 },
-    { name: 'Delivery Jumpstart', price: 12000 },
-    { name: 'AI Readiness', price: 9000 },
+    { name: 'Audit Sprint', price: 6000, plan: 'audit-sprint' },
+    { name: 'Delivery Jumpstart', price: 12000, plan: 'delivery-jumpstart' },
+    { name: 'AI Readiness', price: 9000, plan: 'ai-readiness' },
   ]
   return (
     <section id="pricing" className="py-12 border-t border-[rgba(255,255,255,.06)]">
@@ -80,7 +80,13 @@ function Pricing(){
               <li className="flex items-center gap-2"><CheckCircle2 size={16}/> Findings & backlog</li>
               <li className="flex items-center gap-2"><CheckCircle2 size={16}/> 30-day support</li>
             </ul>
-            <a data-book-call onClick={()=>trackPlausible('BookCallClick')} href={bookingUrl} className="mt-4 inline-block rounded-full bg-[color:var(--primary)] text-slate-900 px-4 py-2">Book</a>
+            <BookCTA
+              cta="pricing"
+              plan={c.plan}
+              className="mt-4 inline-block rounded-full bg-[color:var(--primary)] text-slate-900 px-4 py-2"
+            >
+              Book
+            </BookCTA>
           </div>
         ))}
       </div>
@@ -209,7 +215,12 @@ function CTA(){
         <p className="text-slate-300 mt-2">Tell us about your goals. We’ll respond within one business day.</p>
         <div className="mt-6 flex flex-col md:flex-row gap-3 justify-center">
           <a className="rounded-full bg-[color:var(--primary)] text-slate-900 px-5 py-3 inline-flex items-center gap-2" href="mailto:hello@icarius-consulting.com"><Mail size={18}/> Email us</a>
-          <a data-book-call onClick={()=>trackPlausible('BookCallClick')} className="rounded-full border px-5 py-3 inline-flex items-center gap-2" href={bookingUrl}><Phone size={18}/> Book a call</a>
+          <BookCTA
+            cta="contact"
+            className="rounded-full border px-5 py-3 inline-flex items-center gap-2"
+          >
+            <Phone size={18}/> Book a call
+          </BookCTA>
         </div>
       </div>
     </section>

--- a/components/BookCTA.tsx
+++ b/components/BookCTA.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import type { AnchorHTMLAttributes, MouseEvent, ReactNode } from 'react'
+
+import { buildBookingUrl } from '@/lib/booking'
+
+type BookCTAProps = {
+  plan?: string
+  cta?: string
+  children?: ReactNode
+} & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'target' | 'rel'>
+
+export function BookCTA({
+  plan,
+  cta = 'book-cta',
+  children = 'Book a call',
+  className,
+  onClick,
+  ...rest
+}: BookCTAProps) {
+  const href = buildBookingUrl(plan)
+  const dataPlan = plan ?? 'general'
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(event)
+
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.altKey ||
+      event.shiftKey
+    ) {
+      return
+    }
+
+    if (typeof window !== 'undefined') {
+      ;(window as any).plausible?.('BookCallClick', {
+        props: {
+          cta,
+          plan: dataPlan,
+        },
+      })
+    }
+  }
+
+  return (
+    <a
+      {...rest}
+      className={className}
+      href={href}
+      target="_blank"
+      rel="noreferrer noopener"
+      data-cta={cta}
+      data-plan={dataPlan}
+      onClick={handleClick}
+    >
+      {children}
+    </a>
+  )
+}

--- a/components/consent-provider.tsx
+++ b/components/consent-provider.tsx
@@ -2,30 +2,14 @@
 import { useEffect, useState } from 'react'
 import Script from 'next/script'
 
+import { bookingUrl } from '@/lib/booking'
+
 export function ConsentProvider({ children }: { children: React.ReactNode }) {
   const [consent, setConsent] = useState<'unknown'|'all'|'essential'>(() =>
     typeof window !== 'undefined' ? ((localStorage.getItem('icarius_consent') as any) || 'unknown') : 'unknown'
   )
 
   useEffect(() => { if (consent !== 'unknown') localStorage.setItem('icarius_consent', consent) }, [consent])
-
-  // Global click handler for any [data-book-call] element (works across the whole app)
-  useEffect(() => {
-    const onClick = (e: MouseEvent) => {
-      const target = e.target as HTMLElement
-      const trigger = target?.closest?.('[data-book-call]')
-      if (trigger) {
-        if (e.metaKey || e.ctrlKey || e.button !== 0) {
-          return
-        }
-        e.preventDefault()
-        ;(window as any).plausible?.('BookCallClick')
-        document.getElementById('calendly')?.setAttribute('aria-hidden', 'false')
-      }
-    }
-    document.addEventListener('click', onClick)
-    return () => document.removeEventListener('click', onClick)
-  }, [])
 
   return (
     <>
@@ -71,7 +55,7 @@ export function ConsentProvider({ children }: { children: React.ReactNode }) {
           <div
             id="calendlyInline"
             className="calendly-inline-widget"
-            data-url={process.env.NEXT_PUBLIC_CALENDLY_URL || 'https://calendly.com/icarius/intro-call'}
+            data-url={bookingUrl}
             style={{ minWidth: 320, height: 660 }}
           />
           <button

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,105 +1,30 @@
 'use client'
+
 import Image from 'next/image'
 import Link from 'next/link'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 
-import { bookingUrl } from '@/lib/booking'
+import { BookCTA } from '@/components/BookCTA'
 import { primaryNavLinks } from '@/lib/navigation'
 
-function trackPlausible(name:string, props?:Record<string,any>){ if (typeof window!=='undefined' && (window as any).plausible){ (window as any).plausible(name, { props }); } }
-
-// Utility for trapping focus within a modal
-function trapFocus(modal: HTMLElement) {
-  const focusableSelectors = [
-    'a[href]', 'area[href]', 'input:not([disabled])',
-    'select:not([disabled])', 'textarea:not([disabled])',
-    'button:not([disabled])', 'iframe', 'object', 'embed',
-    '[tabindex]:not([tabindex="-1"])', '[contenteditable]'
-  ]
-  const focusableElements = modal.querySelectorAll(focusableSelectors.join(','))
-  const firstElement = focusableElements[0] as HTMLElement | undefined
-  const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement | undefined
-
-  function handleKeyDown(e: KeyboardEvent) {
-    if (e.key === 'Tab') {
-      if (!firstElement || !lastElement) return
-      if (e.shiftKey) {
-        if (document.activeElement === firstElement) {
-          e.preventDefault()
-          lastElement.focus()
-        }
-      } else {
-        if (document.activeElement === lastElement) {
-          e.preventDefault()
-          firstElement.focus()
-        }
-      }
-    } else if (e.key === 'Escape') {
-      // Hide the modal on Escape
-      modal.setAttribute('aria-hidden', 'true')
-    }
-  }
-
-  modal.addEventListener('keydown', handleKeyDown)
-  firstElement?.focus()
-  return () => {
-    modal.removeEventListener('keydown', handleKeyDown)
-  }
-}
-
-export function Header(){
+export function Header() {
   const [solid, setSolid] = useState(false)
-  const lastActiveElement = useRef<HTMLElement | null>(null)
 
-  useEffect(()=>{
+  useEffect(() => {
     const onScroll = () => setSolid(window.scrollY > 8)
     onScroll()
     window.addEventListener('scroll', onScroll)
-    return ()=> window.removeEventListener('scroll', onScroll)
-  },[])
-
-  useEffect(()=>{
-    // Handle dynamic [data-book-call] elements using event delegation
-    const handleBookCallClick = (e: Event) => {
-      const target = e.target as HTMLElement
-      if (target && target.closest('[data-book-call]')) {
-        if (e instanceof MouseEvent) {
-          if (e.metaKey || e.ctrlKey || e.button !== 0) {
-            return
-          }
-        }
-        e.preventDefault()
-        trackPlausible('BookCallClick')
-        const calendly = document.getElementById('calendly')
-        if (calendly) {
-          lastActiveElement.current = document.activeElement as HTMLElement
-          calendly.setAttribute('aria-hidden','false')
-          calendly.setAttribute('tabIndex', '-1')
-          calendly.focus()
-          const removeTrap = trapFocus(calendly)
-          const observer = new MutationObserver(() => {
-            if (calendly.getAttribute('aria-hidden') === 'true' && lastActiveElement.current) {
-              lastActiveElement.current.focus()
-              observer.disconnect()
-              removeTrap()
-            }
-          })
-          observer.observe(calendly, { attributes: true, attributeFilter: ['aria-hidden'] })
-        }
-      }
-    }
-    // Attach event delegation at the document level for dynamic elements
-    document.addEventListener('click', handleBookCallClick)
-    return () => {
-      document.removeEventListener('click', handleBookCallClick)
-    }
-  },[])
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
 
   return (
-    <header className={`sticky top-0 z-40 transition-colors border-b ${solid ? 'backdrop-blur bg-[rgba(11,16,32,.7)]' : 'bg-transparent'}`}>
+    <header
+      className={`sticky top-0 z-40 transition-colors border-b ${
+        solid ? 'backdrop-blur bg-[rgba(11,16,32,.7)]' : 'bg-transparent'
+      }`}
+    >
       <div className="container mx-auto flex items-center justify-between py-3 px-4">
         <Link href="/" className="flex items-center gap-3 font-bold leading-none">
-          {/* Bigger logo using Next.js Image */}
           <Image
             src="/icarius-logo.svg"
             alt="Icarius logo"
@@ -108,7 +33,6 @@ export function Header(){
             className="h-9 w-9 md:h-10 md:w-10"
             priority
           />
-          {/* Larger brand name */}
           <span className="text-xl md:text-2xl tracking-tight">Icarius Consulting</span>
         </Link>
         <nav className="hidden md:flex items-center gap-6 text-sm">
@@ -117,13 +41,12 @@ export function Header(){
               {link.label}
             </Link>
           ))}
-          <a
-            data-book-call
-            href={bookingUrl}
+          <BookCTA
+            cta="header"
             className="inline-flex items-center gap-2 rounded-full border px-4 py-2"
           >
             Book a call
-          </a>
+          </BookCTA>
         </nav>
       </div>
     </header>

--- a/lib/booking.ts
+++ b/lib/booking.ts
@@ -1,1 +1,23 @@
-export const bookingUrl = process.env.NEXT_PUBLIC_CALENDLY_URL ?? 'https://calendly.com/icarius/intro-call'
+const FALLBACK_BOOKING_URL = 'https://calendly.com/icarius/intro-call'
+
+const resolvedBookingUrl =
+  process.env.NEXT_PUBLIC_BOOKING_URL ??
+  process.env.NEXT_PUBLIC_CALENDLY_URL ??
+  FALLBACK_BOOKING_URL
+
+export const bookingUrl = resolvedBookingUrl
+
+export function buildBookingUrl(plan?: string) {
+  if (!plan) {
+    return resolvedBookingUrl
+  }
+
+  try {
+    const url = new URL(resolvedBookingUrl)
+    url.searchParams.set('plan', plan)
+    return url.toString()
+  } catch (error) {
+    const separator = resolvedBookingUrl.includes('?') ? '&' : '?'
+    return `${resolvedBookingUrl}${separator}plan=${encodeURIComponent(plan)}`
+  }
+}


### PR DESCRIPTION
## Summary
- add support for the NEXT_PUBLIC_BOOKING_URL environment variable with plan-aware helper utilities
- introduce a reusable BookCTA client component that fires analytics and standardises booking link attributes
- refactor booking entry points to use the new component or helper and update the consent embed configuration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df13d9313c8330a745076a5290559f