### PR TITLE
Add assistant contact form and webhook integration

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,10 @@
 'use client'
 import { useMemo, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { AnimatePresence, motion } from 'framer-motion'
-import { Calculator, CheckCircle2, ChevronDown, Mail, Phone } from 'lucide-react'
+import { Calculator, CheckCircle2, ChevronDown, Phone } from 'lucide-react'
 
+import { AssistantForm } from '@/components/AssistantForm'
 import { BookCTA } from '@/components/BookCTA'
 
 export default function Page(){
@@ -208,19 +210,30 @@ function FAQ(){
 }
 
 function CTA(){
+  const params = useSearchParams()
+  const defaultPlan = params.get('plan')
+
   return (
     <section id="contact" className="py-16">
-      <div className="card text-center p-10">
-        <h2 className="text-3xl font-semibold">Ready to reduce delivery risk?</h2>
-        <p className="text-slate-300 mt-2">Tell us about your goals. We’ll respond within one business day.</p>
-        <div className="mt-6 flex flex-col md:flex-row gap-3 justify-center">
-          <a className="rounded-full bg-[color:var(--primary)] text-slate-900 px-5 py-3 inline-flex items-center gap-2" href="mailto:hello@icarius-consulting.com"><Mail size={18}/> Email us</a>
-          <BookCTA
-            cta="contact"
-            className="rounded-full border px-5 py-3 inline-flex items-center gap-2"
-          >
-            <Phone size={18}/> Book a call
-          </BookCTA>
+      <div className="card p-8 md:p-10">
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr),minmax(0,420px)] lg:items-start">
+          <div className="space-y-4 text-left">
+            <h2 className="text-3xl font-semibold">Ready to reduce delivery risk?</h2>
+            <p className="text-slate-300">Tell us about your goals. We’ll respond within one business day.</p>
+            <p className="text-sm text-slate-400">
+              Prefer to jump straight to a conversation? Use the booking link and we’ll tailor the agenda.
+            </p>
+            <BookCTA
+              cta="contact"
+              className="inline-flex items-center gap-2 rounded-full border px-5 py-3"
+            >
+              <Phone size={18}/> Book a call
+            </BookCTA>
+          </div>
+          <AssistantForm
+            plan={defaultPlan}
+            className="card p-6 shadow-none"
+          />
         </div>
       </div>
     </section>

--- a/components/AssistantForm.tsx
+++ b/components/AssistantForm.tsx
@@ -1,0 +1,215 @@
+'use client'
+
+import { FormEvent, useMemo, useState } from 'react'
+
+type AssistantFormProps = {
+  plan?: string | null
+  className?: string
+}
+
+type FieldErrors = Partial<Record<'name' | 'email' | 'message', string>>
+
+type SubmitState = 'idle' | 'submitting' | 'success' | 'error'
+
+const EMAIL_PATTERN = /[^\s@]+@[^\s@]+\.[^\s@]+/
+
+export function AssistantForm({ plan, className }: AssistantFormProps) {
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [company, setCompany] = useState('')
+  const [message, setMessage] = useState('')
+  const [errors, setErrors] = useState<FieldErrors>({})
+  const [feedback, setFeedback] = useState('')
+  const [status, setStatus] = useState<SubmitState>('idle')
+
+  const isSubmitting = status === 'submitting'
+  const computedPlan = useMemo(() => plan ?? undefined, [plan])
+  const planLabel = useMemo(() => {
+    if (!computedPlan) {
+      return null
+    }
+
+    const parts = computedPlan.split(/[-_\s]+/g).filter(Boolean)
+    if (parts.length === 0) {
+      return computedPlan
+    }
+
+    return parts
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' ')
+  }, [computedPlan])
+
+  const validate = (): FieldErrors => {
+    const currentErrors: FieldErrors = {}
+
+    if (!name.trim()) {
+      currentErrors.name = 'Name is required.'
+    }
+
+    const normalizedEmail = email.trim()
+    if (!normalizedEmail) {
+      currentErrors.email = 'Email is required.'
+    } else if (!EMAIL_PATTERN.test(normalizedEmail)) {
+      currentErrors.email = 'Enter a valid email address.'
+    }
+
+    if (!message.trim()) {
+      currentErrors.message = 'Message is required.'
+    }
+
+    return currentErrors
+  }
+
+  const resetForm = () => {
+    setName('')
+    setEmail('')
+    setCompany('')
+    setMessage('')
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    setStatus('idle')
+    setFeedback('')
+
+    const fieldErrors = validate()
+    setErrors(fieldErrors)
+
+    if (Object.keys(fieldErrors).length > 0) {
+      setStatus('error')
+      setFeedback('Please fix the errors in the form and try again.')
+      return
+    }
+
+    setStatus('submitting')
+    setFeedback('Sending your message…')
+
+    try {
+      const response = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name.trim(),
+          email: email.trim(),
+          message: message.trim(),
+          company: company.trim() ? company.trim() : undefined,
+          plan: computedPlan,
+        }),
+      })
+
+      const payload = await response.json().catch(() => ({}))
+
+      if (!response.ok) {
+        const firstError = Array.isArray(payload.errors) ? payload.errors[0] : null
+        const messageText =
+          (typeof firstError?.message === 'string' && firstError.message) ||
+          (typeof payload.error === 'string' ? payload.error : 'Something went wrong. Please try again later.')
+
+        setStatus('error')
+        setFeedback(messageText)
+        return
+      }
+
+      setStatus('success')
+      setFeedback('Thanks! We will be in touch shortly.')
+      setErrors({})
+      resetForm()
+    } catch (error) {
+      console.error('Failed to submit contact form', error)
+      setStatus('error')
+      setFeedback('Something went wrong. Please try again later.')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className={className} noValidate>
+      <div className="grid gap-4">
+        {planLabel && (
+          <p className="text-sm text-slate-300">Interested in the <strong>{planLabel}</strong> plan.</p>
+        )}
+
+        <label className="grid gap-1 text-left text-sm">
+          <span className="text-slate-200">Name</span>
+          <input
+            type="text"
+            name="name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            aria-invalid={errors.name ? 'true' : 'false'}
+            aria-describedby={errors.name ? 'assistant-form-name-error' : undefined}
+            className="rounded-md border border-[rgba(255,255,255,.12)] bg-transparent px-3 py-2"
+            required
+          />
+          {errors.name && (
+            <span id="assistant-form-name-error" className="text-xs text-red-400">
+              {errors.name}
+            </span>
+          )}
+        </label>
+
+        <label className="grid gap-1 text-left text-sm">
+          <span className="text-slate-200">Email</span>
+          <input
+            type="email"
+            name="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            aria-invalid={errors.email ? 'true' : 'false'}
+            aria-describedby={errors.email ? 'assistant-form-email-error' : undefined}
+            className="rounded-md border border-[rgba(255,255,255,.12)] bg-transparent px-3 py-2"
+            required
+          />
+          {errors.email && (
+            <span id="assistant-form-email-error" className="text-xs text-red-400">
+              {errors.email}
+            </span>
+          )}
+        </label>
+
+        <label className="grid gap-1 text-left text-sm">
+          <span className="text-slate-200">Company (optional)</span>
+          <input
+            type="text"
+            name="company"
+            value={company}
+            onChange={(event) => setCompany(event.target.value)}
+            className="rounded-md border border-[rgba(255,255,255,.12)] bg-transparent px-3 py-2"
+          />
+        </label>
+
+        <label className="grid gap-1 text-left text-sm">
+          <span className="text-slate-200">Message</span>
+          <textarea
+            name="message"
+            value={message}
+            onChange={(event) => setMessage(event.target.value)}
+            aria-invalid={errors.message ? 'true' : 'false'}
+            aria-describedby={errors.message ? 'assistant-form-message-error' : undefined}
+            className="min-h-[120px] resize-y rounded-md border border-[rgba(255,255,255,.12)] bg-transparent px-3 py-2"
+            required
+          />
+          {errors.message && (
+            <span id="assistant-form-message-error" className="text-xs text-red-400">
+              {errors.message}
+            </span>
+          )}
+        </label>
+
+        <div className="flex items-center justify-between gap-3">
+          <button
+            type="submit"
+            className="rounded-full bg-[color:var(--primary)] px-5 py-2 font-medium text-slate-900 disabled:opacity-70"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Sending…' : 'Send message'}
+          </button>
+        </div>
+
+        <p aria-live="polite" role="status" className="text-sm text-slate-200">
+          {feedback}
+        </p>
+      </div>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- add an AssistantForm client component with client-side validation, aria live messaging, and submit-state handling
- replace the contact mailto link with the form and surface plan defaults from the URL alongside the existing Book CTA
- accept optional company/plan fields in the contact handler, trigger a webhook before logging redacted metadata, and update tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df156971d8833080a4338b656984ca