### PR TITLE
Add canonical metadata for marketing and blog routes

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,6 +4,7 @@ export const metadata: Metadata = {
   title: 'About Icarius Consulting',
   description:
     'Learn about the team, ethos, and operating principles behind Icarius Consulting.',
+  alternates: { canonical: '/about' },
 }
 
 export default function AboutPage() {

--- a/app/accessibility/page.tsx
+++ b/app/accessibility/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Accessibility statement — Icarius Consulting',
   description: 'Steps Icarius Consulting takes to keep this website usable for everyone.',
+  alternates: { canonical: '/accessibility' },
 }
 
 export default function AccessibilityPage() {

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType } from 'react'
+import type { Metadata } from 'next'
 import fs from 'fs/promises'
 import path from 'path'
 import { notFound } from 'next/navigation'
@@ -6,6 +7,46 @@ import { notFound } from 'next/navigation'
 interface BlogPageProps {
   params: {
     slug: string
+  }
+}
+
+type PostModule = {
+  default: ComponentType
+  metadata?: {
+    title?: string
+    description?: string
+  }
+}
+
+function isModuleNotFound(error: unknown) {
+  const missingModuleByCode =
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND'
+  const missingModuleByMessage =
+    error instanceof Error && error.message.includes('Cannot find module')
+
+  return missingModuleByCode || missingModuleByMessage
+}
+
+function formatSlugToTitle(slug: string) {
+  return slug
+    .split('-')
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ')
+}
+
+async function loadPostModule(slug: string): Promise<PostModule> {
+  try {
+    return (await import(`@/content/posts/${slug}.mdx`)) as PostModule
+  } catch (error) {
+    if (isModuleNotFound(error)) {
+      notFound()
+    }
+
+    throw error
   }
 }
 
@@ -34,29 +75,23 @@ export async function generateStaticParams() {
     .map((entry) => ({ slug: entry.replace(/\.mdx$/, '') }))
 }
 
+export async function generateMetadata({ params }: BlogPageProps): Promise<Metadata> {
+  const postModule = await loadPostModule(params.slug)
+  const title = postModule.metadata?.title ?? formatSlugToTitle(params.slug)
+  const description = postModule.metadata?.description
+
+  return {
+    title,
+    description,
+    alternates: { canonical: `/blog/${params.slug}` },
+  }
+}
+
 export default async function BlogPostPage({ params }: BlogPageProps) {
   const { slug } = params
 
-  let Post: ComponentType
-
-  try {
-    Post = (await import(`@/content/posts/${slug}.mdx`)).default
-  } catch (error) {
-    const missingModuleByCode =
-      typeof error === 'object' &&
-      error !== null &&
-      'code' in error &&
-      (error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND'
-    const missingModuleByMessage =
-      error instanceof Error && error.message.includes('Cannot find module')
-    const isMissingModule = missingModuleByCode || missingModuleByMessage
-
-    if (isMissingModule) {
-      notFound()
-    }
-
-    throw error
-  }
+  const postModule = await loadPostModule(slug)
+  const Post = postModule.default
 
   return (
     <article className="prose prose-invert mx-auto">

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,6 +1,13 @@
 import { promises as fs } from 'fs'
 import path from 'path'
 import Link from 'next/link'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Insights — Icarius Consulting',
+  description: 'Browse articles and updates from the Icarius Consulting team.',
+  alternates: { canonical: '/blog' },
+}
 
 export default async function BlogIndex(){
   const dir = path.join(process.cwd(), 'content', 'posts')

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -4,6 +4,7 @@ import { bookingUrl } from '@/lib/booking'
 export const metadata: Metadata = {
   title: 'Contact — Icarius Consulting',
   description: 'Book time with the Icarius team or request more information about our services.',
+  alternates: { canonical: '/contact' },
 }
 
 const contactMethods = [

--- a/app/packages/page.tsx
+++ b/app/packages/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Packages — Icarius Consulting',
   description: 'Choose the engagement model that fits your operational goals and pace.',
+  alternates: { canonical: '/packages' },
 }
 
 const packages = [

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Privacy policy — Icarius Consulting',
   description: 'How Icarius Consulting handles the personal information you share with us.',
+  alternates: { canonical: '/privacy' },
 }
 
 export default function PrivacyPage() {

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -4,6 +4,7 @@ export const metadata: Metadata = {
   title: 'Services — Icarius Consulting',
   description:
     'Explore the consulting services Icarius offers to modernise operations and finance teams.',
+  alternates: { canonical: '/services' },
 }
 
 const services = [

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Terms of service — Icarius Consulting',
   description: 'Commercial terms governing consulting engagements with Icarius Consulting.',
+  alternates: { canonical: '/terms' },
 }
 
 export default function TermsPage() {

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Work — Icarius Consulting',
   description: 'See examples of the outcomes we help operations and finance teams deliver.',
+  alternates: { canonical: '/work' },
 }
 
 const highlights = [


### PR DESCRIPTION
## Summary
- add canonical alternates to the marketing pages and blog index metadata
- ensure dynamic blog posts load consistently and publish a canonical URL for each slug

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df1e74e8888330a0fea0975e3315b9