### PR TITLE
Add sitemap and robots metadata routes

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,32 @@
+import type { MetadataRoute } from 'next'
+
+const FALLBACK_SITE_URL = 'https://www.icarius-consulting.com'
+
+function resolveSiteUrl() {
+  const configuredSiteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? FALLBACK_SITE_URL
+  const normalisedInput = configuredSiteUrl.endsWith('/')
+    ? configuredSiteUrl.slice(0, -1)
+    : configuredSiteUrl
+
+  try {
+    return new URL(normalisedInput).origin
+  } catch {
+    try {
+      return new URL(`https://${normalisedInput}`).origin
+    } catch {
+      return FALLBACK_SITE_URL
+    }
+  }
+}
+
+export default function robots(): MetadataRoute.Robots {
+  const siteUrl = resolveSiteUrl()
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,73 @@
+import type { MetadataRoute } from 'next'
+import fs from 'fs/promises'
+import path from 'path'
+
+import { CASE_STUDIES } from './work/case-studies'
+
+const FALLBACK_SITE_URL = 'https://www.icarius-consulting.com'
+
+function resolveSiteUrl() {
+  const configuredSiteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? FALLBACK_SITE_URL
+  const normalisedInput = configuredSiteUrl.endsWith('/')
+    ? configuredSiteUrl.slice(0, -1)
+    : configuredSiteUrl
+
+  try {
+    return new URL(normalisedInput).origin
+  } catch {
+    try {
+      return new URL(`https://${normalisedInput}`).origin
+    } catch {
+      return FALLBACK_SITE_URL
+    }
+  }
+}
+
+async function getBlogPostSlugs() {
+  const postsDir = path.join(process.cwd(), 'content/posts')
+
+  try {
+    const entries = await fs.readdir(postsDir)
+
+    return entries
+      .filter((entry) => entry.endsWith('.mdx'))
+      .map((entry) => entry.replace(/\.mdx$/, ''))
+      .sort()
+  } catch (error) {
+    const isMissingDirectory =
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as NodeJS.ErrnoException).code === 'ENOENT'
+
+    if (isMissingDirectory) {
+      return []
+    }
+
+    throw error
+  }
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const siteUrl = resolveSiteUrl()
+
+  const staticRoutes = [
+    '/',
+    '/about',
+    '/services',
+    '/work',
+    '/packages',
+    '/blog',
+    '/contact',
+    '/privacy',
+    '/terms',
+    '/accessibility',
+  ]
+
+  const caseStudyRoutes = CASE_STUDIES.map((study) => `/work/${study.slug}`)
+  const blogPostRoutes = (await getBlogPostSlugs()).map((slug) => `/blog/${slug}`)
+
+  return [...staticRoutes, ...caseStudyRoutes, ...blogPostRoutes].map((route) => ({
+    url: route === '/' ? siteUrl : `${siteUrl}${route}`,
+  }))
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.icarius-consulting.com/sitemap.xml


### PR DESCRIPTION
## Summary
- add a dynamic sitemap that resolves the site URL from NEXT_PUBLIC_SITE_URL with a fallback and includes static, blog, and case study routes
- add a robots metadata route that mirrors the allow-all policy and references the sitemap
- provide a static robots.txt fallback for non-App Router environments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df2159fe3c8330b82ddcf6064b009e