### PR TITLE
Add accessibility enhancements to global styles

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -14,6 +14,49 @@
   --muted: #b6bfdb;
 }
 
+:focus-visible {
+  outline: 2px solid var(--primary-2);
+  outline-offset: 4px;
+}
+
+.skip-link {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  background: var(--primary);
+  color: #020617;
+  font-weight: 600;
+  opacity: 0;
+  transform: translateY(-150%);
+  transition: transform 0.2s ease, opacity 0.2s ease;
+  z-index: 999;
+}
+
+.skip-link:focus-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html:focus-within {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .skip-link {
+    transition: none;
+  }
+}
+
 html, body {
   /* fallback */
   background-color: var(--bg);
@@ -25,15 +68,57 @@ html, body {
   color: var(--text);
   background-attachment: fixed;
 }
-.container { max-width: 1100px; }
-
-.card{ @apply rounded-2xl p-4; border:1px solid rgba(255,255,255,.06); background: linear-gradient(180deg, var(--surface), var(--surface-2)); box-shadow: 0 20px 60px rgba(0,0,0,.30); transition: transform .15s ease, box-shadow .15s ease; }
-@media (prefers-reduced-motion: no-preference){
-  .card:hover{ transform: translateY(-2px); box-shadow: 0 8px 20px rgba(2,6,23,.28); }
+.container {
+  max-width: 1100px;
 }
-.mini-link{ @apply inline-block mt-1 text-sm; border-bottom: 1px solid rgba(255,255,255,.20); }
-.stars{ color: #f59e0b; letter-spacing: .08em; font-size: 14px; margin: 6px 0; }
 
-.modal{position:fixed;inset:0;background:rgba(0,0,0,.45);display:none;align-items:center;justify-content:center;padding:16px;z-index:60}
-.modal[aria-hidden="false"]{display:flex}
-.modal-box{background:linear-gradient(160deg,var(--surface),var(--surface-2));border-radius:16px;padding:16px;max-width:720px;width:100%;border:1px solid rgba(255,255,255,.12)}
+.card {
+  @apply rounded-2xl p-4;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: linear-gradient(180deg, var(--surface), var(--surface-2));
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(2, 6, 23, 0.28);
+  }
+}
+
+.mini-link {
+  @apply inline-block mt-1 text-sm;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.stars {
+  color: #f59e0b;
+  letter-spacing: 0.08em;
+  font-size: 14px;
+  margin: 6px 0;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 60;
+}
+
+.modal[aria-hidden="false"] {
+  display: flex;
+}
+
+.modal-box {
+  width: 100%;
+  max-width: 720px;
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(160deg, var(--surface), var(--surface-2));
+}


### PR DESCRIPTION
## Summary
- add global focus-visible outline and skip link styling for improved accessibility
- include prefers-reduced-motion overrides to limit motion for sensitive users
- tidy modal, card, and link styles to match current layout conventions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df269f1fd08330942c86108f8d0452