### PR TITLE
Add skip link for main content access

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,9 +26,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className="bg-transparent text-slate-100">
+        <a href="#main" className="skip-link">Skip to content</a>
         <ConsentProvider>
           <Header />
-          <main id="content" className="container mx-auto px-4">
+          <main id="main" className="container mx-auto px-4">
             {children}
           </main>
           <Footer />


### PR DESCRIPTION
## Summary
- add a skip link at the top of the page body to let keyboard users jump to the main content
- rename the main landmark id so the skip link target resolves correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df271f2c1c8330978cf46347c41c44