### PR TITLE
Implement consent banner and gate analytics scripts

### DIFF
--- a/app/consent/ConsentBanner.tsx
+++ b/app/consent/ConsentBanner.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+const STORAGE_KEY = 'icarius_consent'
+const CONSENT_GRANTED = 'granted'
+const CONSENT_DENIED = 'denied'
+
+const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[]
+    gtag?: (...args: unknown[]) => void
+    __analyticsLoaded?: boolean
+    __gtmLoaded?: boolean
+  }
+}
+
+const injectScript = (id: string, src: string) => {
+  if (typeof document === 'undefined' || document.getElementById(id)) {
+    return
+  }
+
+  const script = document.createElement('script')
+  script.id = id
+  script.async = true
+  script.src = src
+  document.head?.appendChild(script)
+}
+
+export const loadAnalytics = () => {
+  if (typeof window === 'undefined') return
+  if (window.__analyticsLoaded) return
+
+  window.__analyticsLoaded = true
+  window.dataLayer = window.dataLayer || []
+
+  const gtag = window.gtag ?? ((...args: unknown[]) => {
+    window.dataLayer?.push(args)
+  })
+
+  window.gtag = gtag
+  gtag('consent', 'update', { analytics_storage: 'granted' })
+
+  if (GTM_ID && !window.__gtmLoaded) {
+    window.__gtmLoaded = true
+    window.dataLayer?.push({ 'gtm.start': Date.now(), event: 'gtm.js' })
+    injectScript('gtm-script', `https://www.googletagmanager.com/gtm.js?id=${GTM_ID}`)
+  }
+
+  if (GA_MEASUREMENT_ID) {
+    injectScript(
+      'ga-script',
+      `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`,
+    )
+    gtag('js', new Date())
+    gtag('config', GA_MEASUREMENT_ID, { anonymize_ip: true })
+  }
+}
+
+const updateDeniedConsent = () => {
+  if (typeof window === 'undefined') return
+  window.gtag?.('consent', 'update', { analytics_storage: 'denied' })
+}
+
+export function ConsentBanner() {
+  const [consent, setConsent] = useState<'unknown' | typeof CONSENT_GRANTED | typeof CONSENT_DENIED>('unknown')
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const stored = window.localStorage.getItem(STORAGE_KEY)
+    if (stored === CONSENT_GRANTED || stored === CONSENT_DENIED) {
+      setConsent(stored)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (consent === 'unknown' || typeof window === 'undefined') {
+      return
+    }
+
+    window.localStorage.setItem(STORAGE_KEY, consent)
+
+    if (consent === CONSENT_GRANTED) {
+      loadAnalytics()
+    } else {
+      updateDeniedConsent()
+    }
+  }, [consent])
+
+  const allowAnalytics = useCallback(() => setConsent(CONSENT_GRANTED), [])
+  const essentialOnly = useCallback(() => setConsent(CONSENT_DENIED), [])
+
+  const banner = useMemo(() => {
+    if (consent !== 'unknown') return null
+
+    return (
+      <div className="fixed inset-0 flex items-end justify-center p-4 z-50">
+        <div className="bg-[linear-gradient(160deg,var(--surface),var(--surface-2))] border border-[rgba(255,255,255,.12)] rounded-2xl p-4 w-full max-w-xl shadow-lg">
+          <p className="text-sm">
+            <strong>Cookies & analytics</strong>
+            <br />
+            <span className="text-slate-300">
+              We use analytics to understand how the site is used. No marketing cookies.
+            </span>
+          </p>
+          <div className="flex gap-2 mt-2">
+            <button onClick={allowAnalytics} className="rounded-full bg-[color:var(--primary)] text-slate-900 px-4 py-2">
+              Allow analytics
+            </button>
+            <button onClick={essentialOnly} className="rounded-full border px-4 py-2">
+              Essential only
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }, [allowAnalytics, essentialOnly, consent])
+
+  return banner
+}
+
+export const hasAnalyticsConsent = () => {
+  if (typeof window === 'undefined') return false
+  return window.localStorage.getItem(STORAGE_KEY) === CONSENT_GRANTED
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import '@/styles/globals.css'
-import { ConsentProvider } from '@/components/consent-provider'
+import { SiteProviders } from '@/components/consent-provider'
 import { Header } from '@/components/header'
 import { Footer } from '@/components/footer'
 import { inter } from '@/app/fonts'
@@ -26,15 +26,34 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              window.gtag = window.gtag || gtag;
+              gtag('consent', 'default', {
+                analytics_storage: 'denied',
+                ad_storage: 'denied',
+                ad_user_data: 'denied',
+                ad_personalization: 'denied',
+                functionality_storage: 'denied',
+                security_storage: 'granted'
+              });
+            `,
+          }}
+        />
+      </head>
       <body className={`${inter.className} bg-transparent text-slate-100`}>
         <a href="#main" className="skip-link">Skip to content</a>
-        <ConsentProvider>
+        <SiteProviders>
           <Header />
           <main id="main" className="container mx-auto px-4">
             {children}
           </main>
           <Footer />
-        </ConsentProvider>
+        </SiteProviders>
       </body>
     </html>
   )

--- a/components/BookCTA.tsx
+++ b/components/BookCTA.tsx
@@ -2,6 +2,8 @@
 
 import type { AnchorHTMLAttributes, MouseEvent, ReactNode } from 'react'
 
+import { hasAnalyticsConsent } from '@/app/consent/ConsentBanner'
+
 import { buildBookingUrl } from '@/lib/booking'
 
 type BookCTAProps = {
@@ -35,13 +37,19 @@ export function BookCTA({
       return
     }
 
-    if (typeof window !== 'undefined') {
-      ;(window as any).plausible?.('BookCallClick', {
-        props: {
-          cta,
-          plan: dataPlan,
-        },
+    if (typeof window !== 'undefined' && hasAnalyticsConsent()) {
+      ;(window as any).dataLayer?.push({
+        event: 'book_call_click',
+        cta,
+        plan: dataPlan,
       })
+      if (typeof (window as any).gtag === 'function') {
+        ;(window as any).gtag('event', 'book_call_click', {
+          event_category: 'engagement',
+          event_label: cta,
+          plan: dataPlan,
+        })
+      }
     }
   }
 

--- a/components/consent-provider.tsx
+++ b/components/consent-provider.tsx
@@ -1,29 +1,13 @@
 'use client'
-import { useEffect, useState } from 'react'
+
 import Script from 'next/script'
 
+import { ConsentBanner } from '@/app/consent/ConsentBanner'
 import { bookingUrl } from '@/lib/booking'
 
-export function ConsentProvider({ children }: { children: React.ReactNode }) {
-  const [consent, setConsent] = useState<'unknown'|'all'|'essential'>(() =>
-    typeof window !== 'undefined' ? ((localStorage.getItem('icarius_consent') as any) || 'unknown') : 'unknown'
-  )
-
-  useEffect(() => { if (consent !== 'unknown') localStorage.setItem('icarius_consent', consent) }, [consent])
-
+export function SiteProviders({ children }: { children: React.ReactNode }) {
   return (
     <>
-      {/* Load Plausible only after consent */}
-      {consent === 'all' && (
-        <Script
-          id="plausible"
-          strategy="afterInteractive"
-          data-domain={process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN || 'icarius-consulting.com'}
-          src="https://plausible.io/js/plausible.js"
-        />
-      )}
-
-      {/* Calendly inline embed script (required for the inline widget) */}
       <Script
         id="calendly-widget"
         strategy="afterInteractive"
@@ -32,23 +16,8 @@ export function ConsentProvider({ children }: { children: React.ReactNode }) {
 
       {children}
 
-      {/* Minimal consent banner */}
-      {consent === 'unknown' && (
-        <div className="fixed inset-0 flex items-end justify-center p-4 z-50">
-          <div className="bg-[linear-gradient(160deg,var(--surface),var(--surface-2))] border border-[rgba(255,255,255,.12)] rounded-2xl p-4 w-full max-w-xl shadow-lg">
-            <p className="text-sm">
-              <strong>Cookies & analytics</strong><br />
-              <span className="text-slate-300">We use privacy-friendly analytics to improve this site. No marketing cookies.</span>
-            </p>
-            <div className="flex gap-2 mt-2">
-              <button onClick={() => setConsent('all')} className="rounded-full bg-[color:var(--primary)] text-slate-900 px-4 py-2">Allow analytics</button>
-              <button onClick={() => setConsent('essential')} className="rounded-full border px-4 py-2">Essential only</button>
-            </div>
-          </div>
-        </div>
-      )}
+      <ConsentBanner />
 
-      {/* Calendly modal */}
       <div className="modal" id="calendly" aria-hidden="true" role="dialog" aria-modal="true">
         <div className="modal-box" role="document">
           <h3 className="text-xl font-semibold">Book an intro call</h3>


### PR DESCRIPTION
## Summary
- add a default-deny Google consent snippet in the root layout head and wrap the app with the new SiteProviders component
- introduce a reusable consent banner that persists analytics preferences, loads GTM/GA only after approval, and export a helper for checking consent
- gate BookCTA analytics events behind stored consent while keeping Calendly integration in the shared providers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df27f582708330a9010342833b5036