### PR TITLE
Convert landing page widgets to dynamic client components

### DIFF
--- a/components/BookCTA.tsx
+++ b/components/BookCTA.tsx
@@ -1,97 +1,12 @@
 'use client'
 
 import {
-  type AnchorHTMLAttributes,
-  type MouseEvent,
-  type ReactNode,
-  useCallback,
-  useRef,
-  useState,
-} from 'react'
+  ContactModalTrigger,
+  type ContactModalTriggerProps,
+} from '@/components/ContactModal'
 
-import { hasAnalyticsConsent } from '@/app/consent/ConsentBanner'
+export type BookCTAProps = ContactModalTriggerProps
 
-import { buildBookingUrl } from '@/lib/booking'
-import { ContactModal } from '@/components/ContactModal'
-
-type BookCTAProps = {
-  plan?: string
-  cta?: string
-  children?: ReactNode
-} & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'target' | 'rel'>
-
-export function BookCTA({
-  plan,
-  cta = 'book-cta',
-  children = 'Book a call',
-  className,
-  onClick,
-  ...rest
-}: BookCTAProps) {
-  const href = buildBookingUrl(plan)
-  const dataPlan = plan ?? 'general'
-  const triggerRef = useRef<HTMLAnchorElement | null>(null)
-  const [modalOpen, setModalOpen] = useState(false)
-
-  const closeModal = useCallback(() => {
-    setModalOpen(false)
-  }, [])
-
-  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
-    onClick?.(event)
-
-    if (
-      event.defaultPrevented ||
-      event.button !== 0 ||
-      event.metaKey ||
-      event.ctrlKey ||
-      event.altKey ||
-      event.shiftKey
-    ) {
-      return
-    }
-
-    event.preventDefault()
-
-    if (typeof window !== 'undefined' && hasAnalyticsConsent()) {
-      ;(window as any).dataLayer?.push({
-        event: 'book_call_click',
-        cta,
-        plan: dataPlan,
-      })
-      if (typeof (window as any).gtag === 'function') {
-        ;(window as any).gtag('event', 'book_call_click', {
-          event_category: 'engagement',
-          event_label: cta,
-          plan: dataPlan,
-        })
-      }
-    }
-
-    setModalOpen(true)
-  }
-
-  return (
-    <>
-      <a
-        {...rest}
-        ref={triggerRef}
-        className={className}
-        href={href}
-        data-cta={cta}
-        data-plan={dataPlan}
-        onClick={handleClick}
-        aria-haspopup="dialog"
-        aria-expanded={modalOpen}
-      >
-        {children}
-      </a>
-      <ContactModal
-        open={modalOpen}
-        onClose={closeModal}
-        plan={plan}
-        triggerRef={triggerRef}
-      />
-    </>
-  )
+export function BookCTA(props: BookCTAProps) {
+  return <ContactModalTrigger {...props} />
 }

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -1,13 +1,19 @@
 'use client'
 
 import {
+  type AnchorHTMLAttributes,
+  type MouseEvent,
   type MutableRefObject,
+  type ReactNode,
   type RefObject,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from 'react'
 
+import { hasAnalyticsConsent } from '@/app/consent/ConsentBanner'
 import { buildBookingUrl } from '@/lib/booking'
 
 import { AccessibleModal } from './AccessibleModal'
@@ -67,5 +73,84 @@ export function ContactModal({ open, onClose, plan, triggerRef }: ContactModalPr
         </div>
       </div>
     </AccessibleModal>
+  )
+}
+
+type ContactModalTriggerBaseProps = {
+  plan?: string
+  cta?: string
+  children?: ReactNode
+} & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'target' | 'rel'>
+
+export type ContactModalTriggerProps = ContactModalTriggerBaseProps
+
+export function ContactModalTrigger({
+  plan,
+  cta = 'book-cta',
+  children = 'Book a call',
+  className,
+  onClick,
+  ...rest
+}: ContactModalTriggerProps) {
+  const href = buildBookingUrl(plan)
+  const dataPlan = plan ?? 'general'
+  const triggerRef = useRef<HTMLAnchorElement | null>(null)
+  const [modalOpen, setModalOpen] = useState(false)
+
+  const closeModal = useCallback(() => {
+    setModalOpen(false)
+  }, [])
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(event)
+
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.altKey ||
+      event.shiftKey
+    ) {
+      return
+    }
+
+    event.preventDefault()
+
+    if (typeof window !== 'undefined' && hasAnalyticsConsent()) {
+      ;(window as any).dataLayer?.push({
+        event: 'book_call_click',
+        cta,
+        plan: dataPlan,
+      })
+      if (typeof (window as any).gtag === 'function') {
+        ;(window as any).gtag('event', 'book_call_click', {
+          event_category: 'engagement',
+          event_label: cta,
+          plan: dataPlan,
+        })
+      }
+    }
+
+    setModalOpen(true)
+  }
+
+  return (
+    <>
+      <a
+        {...rest}
+        ref={triggerRef}
+        className={className}
+        href={href}
+        data-cta={cta}
+        data-plan={dataPlan}
+        onClick={handleClick}
+        aria-haspopup="dialog"
+        aria-expanded={modalOpen}
+      >
+        {children}
+      </a>
+      <ContactModal open={modalOpen} onClose={closeModal} plan={plan} triggerRef={triggerRef} />
+    </>
   )
 }

--- a/components/ROIWidget.tsx
+++ b/components/ROIWidget.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Calculator } from 'lucide-react'
+
+export function ROIWidget() {
+  const [headcount, setHeadcount] = useState(500)
+  const [salary, setSalary] = useState(55000)
+  const [hours, setHours] = useState(1.5)
+
+  const savings = useMemo(() => {
+    const hourly = salary / 220 / 7.5
+    return Math.round(headcount * hours * hourly * 52)
+  }, [headcount, salary, hours])
+
+  return (
+    <section className="py-12 border-t border-[rgba(255,255,255,.06)]">
+      <h2 className="text-2xl font-semibold flex items-center gap-2">
+        <Calculator size={20} /> ROI Calculator
+      </h2>
+      <div className="grid md:grid-cols-4 gap-4 mt-4 items-end">
+        <label className="block">
+          <div className="text-sm text-slate-400 mb-1">Employees</div>
+          <input
+            type="range"
+            min={50}
+            max={10000}
+            value={headcount}
+            onChange={(event) => setHeadcount(Number(event.target.value))}
+            className="w-full"
+          />
+          <div className="text-sm text-slate-400">{headcount.toLocaleString()}</div>
+        </label>
+        <label className="block">
+          <div className="text-sm text-slate-400 mb-1">Average salary (£)</div>
+          <input
+            type="number"
+            value={salary}
+            onChange={(event) => setSalary(Number(event.target.value))}
+            className="w-full border rounded px-3 py-2 bg-transparent"
+          />
+        </label>
+        <label className="block">
+          <div className="text-sm text-slate-400 mb-1">Hours saved / week</div>
+          <input
+            type="number"
+            step="0.1"
+            value={hours}
+            onChange={(event) => setHours(Number(event.target.value))}
+            className="w-full border rounded px-3 py-2 bg-transparent"
+          />
+        </label>
+        <div className="card">
+          <div className="text-sm text-slate-400">Estimated annual value</div>
+          <div className="text-3xl font-bold">£{savings.toLocaleString()}</div>
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- extract the ROI calculator into a dedicated `ROIWidget` client component for lazy loading
- expose a reusable contact modal trigger from `ContactModal` and have `BookCTA` reuse it
- convert the home page to a server component, loading the ROI calculator and modal trigger dynamically and simplifying the FAQ accordion

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df2c94d6bc83309aa8f772440c3e8a