### PR TITLE
Add Section wrapper with intersection observer

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
 
+import { Section } from '@/components/Section'
+
 export const metadata: Metadata = {
   title: 'About Icarius Consulting',
   description:
@@ -9,7 +11,7 @@ export const metadata: Metadata = {
 
 export default function AboutPage() {
   return (
-    <section className="py-16">
+    <Section className="py-16">
       <div className="container mx-auto max-w-3xl px-4">
         <div className="space-y-6">
           <h1 className="text-4xl font-semibold tracking-tight">About Icarius Consulting</h1>
@@ -32,6 +34,6 @@ export default function AboutPage() {
           </p>
         </div>
       </div>
-    </section>
+    </Section>
   )
 }

--- a/app/accessibility/page.tsx
+++ b/app/accessibility/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
 
+import { Section } from '@/components/Section'
+
 export const metadata: Metadata = {
   title: 'Accessibility statement — Icarius Consulting',
   description: 'Steps Icarius Consulting takes to keep this website usable for everyone.',
@@ -8,7 +10,7 @@ export const metadata: Metadata = {
 
 export default function AccessibilityPage() {
   return (
-    <section className="py-12">
+    <Section className="py-12">
       <div className="prose prose-invert max-w-3xl mx-auto">
         <h1>Accessibility statement</h1>
         <p>
@@ -37,6 +39,6 @@ export default function AccessibilityPage() {
         </p>
         <p>Last updated: {new Date().toLocaleDateString('en-GB')}</p>
       </div>
-    </section>
+    </Section>
   )
 }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -3,6 +3,8 @@ import path from 'path'
 import Link from 'next/link'
 import type { Metadata } from 'next'
 
+import { Section } from '@/components/Section'
+
 export const metadata: Metadata = {
   title: 'Insights — Icarius Consulting',
   description: 'Browse articles and updates from the Icarius Consulting team.',
@@ -13,7 +15,7 @@ export default async function BlogIndex(){
   const dir = path.join(process.cwd(), 'content', 'posts')
   const files = (await fs.readdir(dir)).filter(f => f.endsWith('.mdx'))
   return (
-    <section className="py-12">
+    <Section className="py-12">
       <h1 className="text-3xl font-semibold">Insights</h1>
       <ul className="mt-4 grid gap-3">
         {files.map(f => {
@@ -21,6 +23,6 @@ export default async function BlogIndex(){
           return <li key={slug}><Link className="mini-link" href={`/blog/${slug}`}>{slug.replace(/-/g,' ')}</Link></li>
         })}
       </ul>
-    </section>
+    </Section>
   )
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { bookingUrl } from '@/lib/booking'
+import { Section } from '@/components/Section'
 
 export const metadata: Metadata = {
   title: 'Contact — Icarius Consulting',
@@ -28,7 +29,7 @@ const contactMethods = [
 
 export default function ContactPage() {
   return (
-    <section className="py-16">
+    <Section className="py-16">
       <div className="container mx-auto max-w-3xl px-4">
         <div className="space-y-6">
           <header className="space-y-4">
@@ -58,6 +59,6 @@ export default function ContactPage() {
           </ul>
         </div>
       </div>
-    </section>
+    </Section>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { SiteProviders } from '@/components/consent-provider'
 import { Header } from '@/components/header'
 import { Footer } from '@/components/footer'
 import { inter } from '@/app/fonts'
+import { ViewObserver } from '@/app/providers'
 
 export const metadata: Metadata = {
   title: 'Icarius Consulting — HRIT Advisory & Delivery',
@@ -46,6 +47,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
       </head>
       <body className={`${inter.className} bg-transparent text-slate-100`}>
+        <ViewObserver />
         <a href="#main" className="skip-link">Skip to content</a>
         <SiteProviders>
           <Header />

--- a/app/packages/page.tsx
+++ b/app/packages/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
 
+import { Section } from '@/components/Section'
+
 export const metadata: Metadata = {
   title: 'Packages — Icarius Consulting',
   description: 'Choose the engagement model that fits your operational goals and pace.',
@@ -26,7 +28,7 @@ const packages = [
 
 export default function PackagesPage() {
   return (
-    <section className="py-16">
+    <Section className="py-16">
       <div className="container mx-auto max-w-4xl px-4">
         <div className="space-y-10">
           <header className="space-y-4">
@@ -49,6 +51,6 @@ export default function PackagesPage() {
           </div>
         </div>
       </div>
-    </section>
+    </Section>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,13 +5,14 @@ import { CheckCircle2, ChevronDown, Phone } from 'lucide-react'
 import { AssistantForm } from '@/components/AssistantForm'
 import type { ContactModalTriggerProps } from '@/components/ContactModal'
 import { HeroIllustration } from '@/components/HeroIllustration'
+import { Section } from '@/components/Section'
 
 const DynamicROIWidget = dynamic(() => import('@/components/ROIWidget').then((mod) => mod.ROIWidget), {
   ssr: false,
   loading: () => (
-    <section className="py-12 border-t border-[rgba(255,255,255,.06)]">
+    <Section className="py-12 border-t border-[rgba(255,255,255,.06)]">
       <div className="h-40 animate-pulse rounded-lg border border-white/10 bg-white/5" />
-    </section>
+    </Section>
   ),
 })
 
@@ -53,7 +54,7 @@ export default function Page({ searchParams }: PageProps) {
 
 function CTAFallback() {
   return (
-    <section id="contact" className="py-16">
+    <Section id="contact" className="py-16">
       <div className="card p-8 md:p-10 animate-pulse">
         <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr),minmax(0,420px)] lg:items-start">
           <div className="space-y-4">
@@ -70,13 +71,13 @@ function CTAFallback() {
           </div>
         </div>
       </div>
-    </section>
+    </Section>
   )
 }
 
 function Hero() {
   return (
-    <section className="py-16 md:py-24">
+    <Section className="py-16 md:py-24">
       <div className="grid md:grid-cols-2 gap-10 items-center">
         <div>
           <h1 className="text-4xl md:text-6xl font-semibold tracking-tight">
@@ -94,13 +95,13 @@ function Hero() {
         </div>
         <HeroIllustration />
       </div>
-    </section>
+    </Section>
   )
 }
 
 function Services() {
   return (
-    <section id="services" className="py-12 border-t border-[rgba(255,255,255,.06)]">
+    <Section id="services" className="py-12 border-t border-[rgba(255,255,255,.06)]">
       <h2 className="text-2xl font-semibold">What we do</h2>
       <ul className="mt-4 grid md:grid-cols-4 gap-4">
         <li className="card"><h3 className="font-semibold">HRIT Advisory</h3><p className="text-slate-300 text-sm mt-1">Target architecture, integration patterns, and build/buy guidance tailored to HR.</p></li>
@@ -108,7 +109,7 @@ function Services() {
         <li className="card"><h3 className="font-semibold">System Audits</h3><p className="text-slate-300 text-sm mt-1">Fact‑based config &amp; data reviews with prioritised fixes.</p></li>
         <li className="card"><h3 className="font-semibold">AI Solutions</h3><p className="text-slate-300 text-sm mt-1">Pragmatic automation for HR Ops and knowledge.</p></li>
       </ul>
-    </section>
+    </Section>
   )
 }
 
@@ -120,7 +121,7 @@ function Pricing() {
   ] as const
 
   return (
-    <section id="pricing" className="py-12 border-t border-[rgba(255,255,255,.06)]">
+    <Section id="pricing" className="py-12 border-t border-[rgba(255,255,255,.06)]">
       <h2 className="text-2xl font-semibold">Packages</h2>
       <div className="mt-4 grid md:grid-cols-3 gap-4">
         {cards.map((card) => (
@@ -142,26 +143,26 @@ function Pricing() {
           </div>
         ))}
       </div>
-    </section>
+    </Section>
   )
 }
 
 function Work() {
   return (
-    <section id="work" className="py-12 border-t border-[rgba(255,255,255,.06)]">
+    <Section id="work" className="py-12 border-t border-[rgba(255,255,255,.06)]">
       <h2 className="text-2xl font-semibold">Selected Work</h2>
       <ul className="mt-4 grid md:grid-cols-3 gap-4">
         <li id="cs-hcm" className="card"><h3 className="font-semibold">Global HCM replacement</h3><p className="text-sm text-slate-300 mt-1">Vendor selection and readiness for 40k employees.</p></li>
         <li id="cs-payroll" className="card"><h3 className="font-semibold">Payroll consolidation</h3><p className="text-sm text-slate-300 mt-1">12‑country integration and control framework.</p></li>
         <li id="cs-ai" className="card"><h3 className="font-semibold">HR Ops AI assistant</h3><p className="text-sm text-slate-300 mt-1">Reduced resolution time by 34%.</p></li>
       </ul>
-    </section>
+    </Section>
   )
 }
 
 function Testimonials() {
   return (
-    <section className="py-12 border-t border-[rgba(255,255,255,.06)]">
+    <Section className="py-12 border-t border-[rgba(255,255,255,.06)]">
       <h2 className="text-2xl font-semibold">What clients say</h2>
       <ul className="mt-4 grid md:grid-cols-3 gap-4">
         <li className="card grid grid-cols-[auto,1fr] gap-3 items-start">
@@ -192,7 +193,7 @@ function Testimonials() {
           </div>
         </li>
       </ul>
-    </section>
+    </Section>
   )
 }
 
@@ -204,7 +205,7 @@ function FAQ() {
   ] as const
 
   return (
-    <section className="py-12 border-t border-[rgba(255,255,255,.06)]">
+    <Section className="py-12 border-t border-[rgba(255,255,255,.06)]">
       <h2 className="text-2xl font-semibold">FAQ</h2>
       <ul className="divide-y divide-[rgba(255,255,255,.06)]">
         {qas.map((qa, index) => (
@@ -219,13 +220,13 @@ function FAQ() {
           </li>
         ))}
       </ul>
-    </section>
+    </Section>
   )
 }
 
 function CTA({ defaultPlan }: { defaultPlan?: string }) {
   return (
-    <section id="contact" className="py-16">
+    <Section id="contact" className="py-16">
       <div className="card p-8 md:p-10">
         <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr),minmax(0,420px)] lg:items-start">
           <div className="space-y-4 text-left">
@@ -245,6 +246,6 @@ function CTA({ defaultPlan }: { defaultPlan?: string }) {
           <AssistantForm plan={defaultPlan} className="card p-6 shadow-none" />
         </div>
       </div>
-    </section>
+    </Section>
   )
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
 
+import { Section } from '@/components/Section'
+
 export const metadata: Metadata = {
   title: 'Privacy policy — Icarius Consulting',
   description: 'How Icarius Consulting handles the personal information you share with us.',
@@ -8,7 +10,7 @@ export const metadata: Metadata = {
 
 export default function PrivacyPage() {
   return (
-    <section className="py-12">
+    <Section className="py-12">
       <div className="prose prose-invert max-w-3xl mx-auto">
         <h1>Privacy policy</h1>
         <p>
@@ -55,6 +57,6 @@ export default function PrivacyPage() {
         </p>
         <p>Last updated: {new Date().toLocaleDateString('en-GB')}</p>
       </div>
-    </section>
+    </Section>
   )
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useEffect } from 'react'
+
+function observeSections() {
+  const observed = new Set<Element>()
+  const intersectionObserver = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('in-view')
+        } else {
+          entry.target.classList.remove('in-view')
+        }
+      })
+    },
+    {
+      rootMargin: '0px 0px -10% 0px',
+      threshold: 0.1,
+    }
+  )
+
+  const register = () => {
+    document.querySelectorAll('.observe').forEach((element) => {
+      if (!observed.has(element)) {
+        observed.add(element)
+        intersectionObserver.observe(element)
+      }
+    })
+  }
+
+  register()
+
+  const mutationObserver = new MutationObserver(() => {
+    register()
+  })
+
+  mutationObserver.observe(document.body, {
+    childList: true,
+    subtree: true,
+  })
+
+  return () => {
+    mutationObserver.disconnect()
+    observed.forEach((element) => intersectionObserver.unobserve(element))
+    intersectionObserver.disconnect()
+  }
+}
+
+export function ViewObserver() {
+  useEffect(() => {
+    return observeSections()
+  }, [])
+
+  return null
+}

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
 
+import { Section } from '@/components/Section'
+
 export const metadata: Metadata = {
   title: 'Services — Icarius Consulting',
   description:
@@ -32,7 +34,7 @@ const services = [
 
 export default function ServicesPage() {
   return (
-    <section className="py-16">
+    <Section className="py-16">
       <div className="container mx-auto max-w-4xl px-4">
         <div className="space-y-10">
           <header className="space-y-4">
@@ -52,6 +54,6 @@ export default function ServicesPage() {
           </dl>
         </div>
       </div>
-    </section>
+    </Section>
   )
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
 
+import { Section } from '@/components/Section'
+
 export const metadata: Metadata = {
   title: 'Terms of service — Icarius Consulting',
   description: 'Commercial terms governing consulting engagements with Icarius Consulting.',
@@ -8,7 +10,7 @@ export const metadata: Metadata = {
 
 export default function TermsPage() {
   return (
-    <section className="py-12">
+    <Section className="py-12">
       <div className="prose prose-invert max-w-3xl mx-auto">
         <h1>Terms of service</h1>
         <p>
@@ -57,6 +59,6 @@ export default function TermsPage() {
         </p>
         <p>Last updated: {new Date().toLocaleDateString('en-GB')}</p>
       </div>
-    </section>
+    </Section>
   )
 }

--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 import { Fragment } from 'react'
 
 import { CASE_STUDIES } from '../case-studies'
+import { Section } from '@/components/Section'
 
 type Params = {
   params: {
@@ -66,7 +67,7 @@ export default function CaseStudyPage({ params }: Params) {
           <p className="text-lg text-slate-300">{study.hero.description}</p>
         </header>
 
-        <section className="mt-10 grid gap-6 md:grid-cols-2">
+        <Section className="mt-10 grid gap-6 md:grid-cols-2">
           <div className="rounded-3xl border border-[rgba(255,255,255,0.08)] bg-slate-950/40 p-6">
             <h2 className="text-base font-semibold text-white">Project snapshot</h2>
             <dl className="mt-4 text-sm text-slate-300">
@@ -93,9 +94,9 @@ export default function CaseStudyPage({ params }: Params) {
               ))}
             </ul>
           </div>
-        </section>
+        </Section>
 
-        <section className="mt-12 space-y-12">
+        <Section className="mt-12 space-y-12">
           <div>
             <h2 className="text-2xl font-semibold text-white">The challenge</h2>
             <ul className="mt-4 space-y-3 text-base text-slate-300">
@@ -119,15 +120,15 @@ export default function CaseStudyPage({ params }: Params) {
               ))}
             </div>
           </div>
-        </section>
+        </Section>
 
         {study.testimonial ? (
-          <section className="mt-12 rounded-3xl border border-[rgba(255,255,255,0.08)] bg-slate-900/50 p-8">
+          <Section className="mt-12 rounded-3xl border border-[rgba(255,255,255,0.08)] bg-slate-900/50 p-8">
             <blockquote className="text-xl font-medium text-white">“{study.testimonial.quote}”</blockquote>
             <p className="mt-4 text-sm text-slate-300">
               — {study.testimonial.person}, {study.testimonial.role}
             </p>
-          </section>
+          </Section>
         ) : null}
       </div>
     </article>

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 
 import { CASE_STUDIES } from './case-studies'
+import { Section } from '@/components/Section'
 
 export const metadata: Metadata = {
   title: 'Work — Icarius Consulting',
@@ -11,7 +12,7 @@ export const metadata: Metadata = {
 
 export default function WorkPage() {
   return (
-    <section className="py-16">
+    <Section className="py-16">
       <div className="container mx-auto px-4 md:px-6">
         <div className="mx-auto max-w-3xl text-center">
           <p className="text-sm font-medium uppercase tracking-[0.2em] text-sky-300/80">Selected work</p>
@@ -41,6 +42,6 @@ export default function WorkPage() {
           ))}
         </div>
       </div>
-    </section>
+    </Section>
   )
 }

--- a/components/ROIWidget.tsx
+++ b/components/ROIWidget.tsx
@@ -3,6 +3,8 @@
 import { useMemo, useState } from 'react'
 import { Calculator } from 'lucide-react'
 
+import { Section } from '@/components/Section'
+
 export function ROIWidget() {
   const [headcount, setHeadcount] = useState(500)
   const [salary, setSalary] = useState(55000)
@@ -14,7 +16,7 @@ export function ROIWidget() {
   }, [headcount, salary, hours])
 
   return (
-    <section className="py-12 border-t border-[rgba(255,255,255,.06)]">
+    <Section className="py-12 border-t border-[rgba(255,255,255,.06)]">
       <h2 className="text-2xl font-semibold flex items-center gap-2">
         <Calculator size={20} /> ROI Calculator
       </h2>
@@ -55,6 +57,6 @@ export function ROIWidget() {
           <div className="text-3xl font-bold">£{savings.toLocaleString()}</div>
         </div>
       </div>
-    </section>
+    </Section>
   )
 }

--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -1,0 +1,9 @@
+import { forwardRef, HTMLAttributes } from 'react'
+
+export type SectionProps = HTMLAttributes<HTMLElement>
+
+export const Section = forwardRef<HTMLElement, SectionProps>(function Section({ className, ...props }, ref) {
+  const classes = ['observe', className].filter(Boolean).join(' ')
+
+  return <section ref={ref} className={classes} {...props} />
+})

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -99,3 +99,14 @@ html, body {
   margin: 6px 0;
 }
 
+.observe {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.observe.in-view {
+  opacity: 1;
+  transform: translateY(0);
+}
+


### PR DESCRIPTION
## Summary
- add a reusable Section wrapper that applies the shared observe styles
- introduce the client-side ViewObserver provider to toggle in-view animations
- update marketing pages to use the new Section component and animation styles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df30d0b4888330a7459b7dc2cc1902