### PR TITLE
Ensure main element is focusable for skip link navigation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -51,7 +51,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <a href="#main" className="skip-link">Skip to content</a>
         <SiteProviders>
           <Header />
-          <main id="main" className="container mx-auto px-4">
+          <main id="main" tabIndex={-1} className="container mx-auto px-4">
             {children}
           </main>
           <Footer />


### PR DESCRIPTION
## Summary
- add a tabIndex to the main content element so it can receive focus from the skip link

## Testing
- Manual verification via Playwright in the browser

------
https://chatgpt.com/codex/tasks/task_e_68df36d04c548330bed6fc9791f0a040