### PR TITLE
Add Next.js headers configuration for security policies

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,37 @@ const withMDX = createMDX({
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ['ts', 'tsx', 'md', 'mdx'],
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          {
+            key: 'Permissions-Policy',
+            value:
+              'geolocation=(), microphone=(), camera=(), interest-cohort=()',
+          },
+          {
+            key: 'Content-Security-Policy',
+            value:
+              "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://www.googletagmanager.com https://www.google-analytics.com; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com; frame-src 'self' https://calendly.com https://*.calendly.com https://cal.com https://*.cal.com",
+          },
+        ],
+      },
+    ]
+  },
 }
 
 export default withMDX(nextConfig)


### PR DESCRIPTION
## Summary
- add an async headers() export in next.config.mjs that mirrors the security headers defined in vercel.json

## Testing
- CI=1 npm run build
- npm run start
- curl -I http://localhost:3000/


------
https://chatgpt.com/codex/tasks/task_e_68df4853de5c83309a5298c7b03a59c4