### PR TITLE
Add structured data helper and FAQ JSON-LD

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { bookingUrl } from '@/lib/booking'
 import { Section } from '@/components/Section'
+import { BUSINESS_ADDRESS, CONTACT_EMAIL, CONTACT_PHONE, CONTACT_PHONE_URI } from '@/lib/structured-data'
 
 const title = 'HRIT advisory HR systems audit HR AI PMO contact team'
 const description =
@@ -36,7 +37,7 @@ const contactMethods = [
   },
   {
     label: 'Email the team',
-    href: 'mailto:hello@icarius-consulting.com',
+    href: `mailto:${CONTACT_EMAIL}`,
     description: 'Share context, RFPs, or supporting information and we will reply within one business day.',
     newTab: false,
     cta: 'contact-page-email',
@@ -54,6 +55,14 @@ export default function ContactPage() {
             <p className="text-lg text-slate-300">
               We would love to learn about the challenges in front of you. Choose the option below that
               suits you best and we will respond quickly.
+            </p>
+            <p className="text-sm text-slate-400">
+              Based in {BUSINESS_ADDRESS.addressLocality} {BUSINESS_ADDRESS.postalCode}, {BUSINESS_ADDRESS.addressRegion}, we partner with
+              clients across the UK, EMEA, and North America. Prefer to speak now? Call{' '}
+              <a href={`tel:${CONTACT_PHONE_URI}`} className="text-[color:var(--primary)]">
+                {CONTACT_PHONE}
+              </a>
+              .
             </p>
           </header>
           <ul className="space-y-4">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,10 +5,16 @@ import { Header } from '@/components/header'
 import { Footer } from '@/components/footer'
 import { inter } from '@/app/fonts'
 import { ViewObserver } from '@/app/providers'
+import {
+  buildCoreServiceSchemas,
+  buildLocalBusinessSchema,
+  buildOrganizationSchema,
+  ORGANIZATION_DESCRIPTION,
+  stringifyJsonLd,
+} from '@/lib/structured-data'
 
 const fallbackTitle = 'HRIT advisory HR systems audit HR AI PMO experts guide'
-const fallbackDescription =
-  'Navigate HRIT advisory, HR systems audit, HR AI innovation, and PMO delivery with Icarius—boutique consultants keeping people, process, and platforms in sync.'
+const fallbackDescription = ORGANIZATION_DESCRIPTION
 
 export const metadata: Metadata = {
   title: fallbackTitle,
@@ -33,9 +39,17 @@ export const metadata: Metadata = {
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const metadataBase = metadata.metadataBase ?? new URL('https://www.icarius-consulting.com')
+  const structuredData = stringifyJsonLd([
+    buildOrganizationSchema(metadataBase),
+    buildLocalBusinessSchema(metadataBase),
+    ...buildCoreServiceSchemas(metadataBase),
+  ])
+
   return (
     <html lang="en">
       <head>
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: structuredData }} />
         <script
           dangerouslySetInnerHTML={{
             __html: `

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,8 @@ import { AssistantForm } from '@/components/AssistantForm'
 import type { ContactModalTriggerProps } from '@/components/ContactModal'
 import { HeroIllustration } from '@/components/HeroIllustration'
 import { Section } from '@/components/Section'
+import { metadata as rootMetadata } from '@/app/layout'
+import { buildFaqPageSchema, coreServices, type FAQItem, stringifyJsonLd } from '@/lib/structured-data'
 
 const DynamicROIWidget = dynamic(() => import('@/components/ROIWidget').then((mod) => mod.ROIWidget), {
   ssr: false,
@@ -32,6 +34,18 @@ const DynamicContactTrigger = dynamic<ContactModalTriggerProps>(
 type PageProps = {
   searchParams?: Record<string, string | string[] | undefined>
 }
+
+export const homepageFaqItems = [
+  { question: 'How quickly can we start?', answer: 'We can kick off within 2 weeks, often faster for audits.' },
+  {
+    question: 'Do you work globally?',
+    answer: 'Yes, we deliver across EMEA/NA with remote-first governance.',
+  },
+  {
+    question: 'What systems do you cover?',
+    answer: 'Workday, SuccessFactors, Dayforce, Oracle, plus payroll/ATS/IDM.',
+  },
+] satisfies readonly FAQItem[]
 
 const title = 'HRIT advisory HR systems audit HR AI PMO experts guide'
 const description =
@@ -128,10 +142,12 @@ function Services() {
     <Section id="services" className="py-12 border-t border-[rgba(255,255,255,.06)]">
       <h2 className="text-2xl font-semibold">What we do</h2>
       <ul className="mt-4 grid md:grid-cols-4 gap-4">
-        <li className="card"><h3 className="font-semibold">HRIT Advisory</h3><p className="text-slate-300 text-sm mt-1">Target architecture, integration patterns, and build/buy guidance tailored to HR.</p></li>
-        <li className="card"><h3 className="font-semibold">Project Delivery</h3><p className="text-slate-300 text-sm mt-1">PMO without the drag: RAID, burn‑down, change enablement, and crisp cutover plans.</p></li>
-        <li className="card"><h3 className="font-semibold">System Audits</h3><p className="text-slate-300 text-sm mt-1">Fact‑based config &amp; data reviews with prioritised fixes.</p></li>
-        <li className="card"><h3 className="font-semibold">AI Solutions</h3><p className="text-slate-300 text-sm mt-1">Pragmatic automation for HR Ops and knowledge.</p></li>
+        {coreServices.map((service) => (
+          <li key={service.id} className="card">
+            <h3 className="font-semibold">{service.name}</h3>
+            <p className="text-slate-300 text-sm mt-1">{service.description}</p>
+          </li>
+        ))}
       </ul>
     </Section>
   )
@@ -222,24 +238,27 @@ function Testimonials() {
 }
 
 function FAQ() {
-  const qas = [
-    { q: 'How quickly can we start?', a: 'We can kick off within 2 weeks, often faster for audits.' },
-    { q: 'Do you work globally?', a: 'Yes, we deliver across EMEA/NA with remote-first governance.' },
-    { q: 'What systems do you cover?', a: 'Workday, SuccessFactors, Dayforce, Oracle, plus payroll/ATS/IDM.' },
-  ] as const
+  const faqJsonLd = stringifyJsonLd(
+    buildFaqPageSchema({
+      baseUrl: rootMetadata.metadataBase ?? new URL('https://www.icarius-consulting.com'),
+      path: '/',
+      items: homepageFaqItems,
+    }),
+  )
 
   return (
     <Section className="py-12 border-t border-[rgba(255,255,255,.06)]">
       <h2 className="text-2xl font-semibold">FAQ</h2>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: faqJsonLd }} />
       <ul className="divide-y divide-[rgba(255,255,255,.06)]">
-        {qas.map((qa, index) => (
-          <li key={qa.q + index}>
+        {homepageFaqItems.map((qa, index) => (
+          <li key={qa.question + index}>
             <details className="group py-3">
               <summary className="flex cursor-pointer items-center justify-between gap-3 text-left">
-                <span className="font-medium">{qa.q}</span>
+                <span className="font-medium">{qa.question}</span>
                 <ChevronDown className="transition-transform group-open:rotate-180" />
               </summary>
-              <div className="pt-3 text-slate-300">{qa.a}</div>
+              <div className="pt-3 text-slate-300">{qa.answer}</div>
             </details>
           </li>
         ))}

--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -1,0 +1,167 @@
+const SITE_NAME = 'Icarius Consulting'
+const SITE_DESCRIPTION =
+  'Navigate HRIT advisory, HR systems audit, HR AI innovation, and PMO delivery with Icarius—boutique consultants keeping people, process, and platforms in sync.'
+
+export const ORGANIZATION_NAME = SITE_NAME
+export const ORGANIZATION_DESCRIPTION = SITE_DESCRIPTION
+export const CONTACT_EMAIL = 'hello@icarius-consulting.com'
+export const CONTACT_PHONE = '+44 20 4526 6210'
+export const CONTACT_PHONE_URI = '+442045266210'
+
+export const BUSINESS_ADDRESS = {
+  addressLocality: 'London',
+  addressRegion: 'England',
+  postalCode: 'WC2N',
+  addressCountry: 'GB',
+} as const
+
+export type CoreService = {
+  id: string
+  name: string
+  description: string
+  serviceType: string
+}
+
+export const coreServices = [
+  {
+    id: 'hrit-advisory',
+    name: 'HRIT Advisory',
+    description: 'Target architecture, integration patterns, and build/buy guidance tailored to HR.',
+    serviceType: 'HRIT advisory',
+  },
+  {
+    id: 'pmo-delivery',
+    name: 'Project Delivery',
+    description: 'PMO without the drag: RAID, burn-down, change enablement, and crisp cutover plans.',
+    serviceType: 'PMO delivery',
+  },
+  {
+    id: 'hr-systems-audit',
+    name: 'System Audits',
+    description: 'Fact-based config & data reviews with prioritised fixes.',
+    serviceType: 'HR systems audit',
+  },
+  {
+    id: 'hr-ai',
+    name: 'AI Solutions',
+    description: 'Pragmatic automation for HR Ops and knowledge.',
+    serviceType: 'HR AI solutions',
+  },
+] as const satisfies readonly CoreService[]
+
+const AREA_SERVED = ['United Kingdom', 'EMEA', 'North America'] as const
+
+const ORGANIZATION_ID_FRAGMENT = '#organization'
+const LOCAL_BUSINESS_ID_FRAGMENT = '#local-business'
+
+function resolveWithBase(path: string, baseUrl: URL) {
+  return new URL(path, baseUrl).href
+}
+
+export function buildOrganizationSchema(baseUrl: URL) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    '@id': resolveWithBase(ORGANIZATION_ID_FRAGMENT, baseUrl),
+    name: SITE_NAME,
+    url: baseUrl.href,
+    description: SITE_DESCRIPTION,
+    logo: resolveWithBase('/favicon.svg', baseUrl),
+    contactPoint: [
+      {
+        '@type': 'ContactPoint',
+        contactType: 'customer service',
+        email: CONTACT_EMAIL,
+        telephone: CONTACT_PHONE,
+        areaServed: AREA_SERVED,
+        availableLanguage: ['English'],
+      },
+    ],
+  }
+}
+
+export function buildLocalBusinessSchema(baseUrl: URL) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': ['Organization', 'LocalBusiness', 'ProfessionalService'],
+    '@id': resolveWithBase(LOCAL_BUSINESS_ID_FRAGMENT, baseUrl),
+    name: SITE_NAME,
+    url: baseUrl.href,
+    description: SITE_DESCRIPTION,
+    email: CONTACT_EMAIL,
+    telephone: CONTACT_PHONE,
+    areaServed: AREA_SERVED,
+    address: {
+      '@type': 'PostalAddress',
+      ...BUSINESS_ADDRESS,
+    },
+    parentOrganization: {
+      '@id': resolveWithBase(ORGANIZATION_ID_FRAGMENT, baseUrl),
+    },
+    makesOffer: coreServices.map((service) => ({
+      '@type': 'Offer',
+      itemOffered: {
+        '@id': resolveWithBase(`#service-${service.id}`, baseUrl),
+      },
+    })),
+  }
+}
+
+export function buildCoreServiceSchemas(baseUrl: URL) {
+  const organizationId = resolveWithBase(ORGANIZATION_ID_FRAGMENT, baseUrl)
+
+  return coreServices.map((service) => ({
+    '@context': 'https://schema.org',
+    '@type': 'Service',
+    '@id': resolveWithBase(`#service-${service.id}`, baseUrl),
+    name: service.name,
+    serviceType: service.serviceType,
+    description: service.description,
+    provider: {
+      '@id': organizationId,
+    },
+    areaServed: AREA_SERVED,
+    offers: [
+      {
+        '@type': 'Offer',
+        url: resolveWithBase('#services', baseUrl),
+        priceCurrency: 'GBP',
+        availability: 'https://schema.org/InStock',
+      },
+    ],
+  }))
+}
+
+export type FAQItem = {
+  question: string
+  answer: string
+}
+
+export function buildFaqPageSchema({
+  baseUrl,
+  path = '/',
+  items,
+}: {
+  baseUrl: URL
+  path?: string
+  items: readonly FAQItem[]
+}) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    '@id': resolveWithBase(`${path}#faq`, baseUrl),
+    url: resolveWithBase(path, baseUrl),
+    mainEntity: items.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer,
+      },
+    })),
+  }
+}
+
+export function stringifyJsonLd(data: unknown) {
+  return JSON.stringify(data).replace(/</g, '\\u003c')
+}


### PR DESCRIPTION
## Summary
- add a reusable structured data helper with core service, organization, local business, and FAQ builders
- inject organization/local business/service JSON-LD into the global layout head
- centralise homepage FAQ/Services data and expose matching FAQPage JSON-LD alongside contact copy updates for location and phone

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68dfbd9977808330827ff5d6eed024ae