### PR TITLE
Add case study crosslinks across services and packages

### DIFF
--- a/app/packages/page.tsx
+++ b/app/packages/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from 'next'
 
+import Link from 'next/link'
+
+import { CASE_STUDIES } from '@/app/work/case-studies'
 import { Section } from '@/components/Section'
 
 const title = 'HRIT advisory HR systems audit HR AI PMO packages catalog'
@@ -30,20 +33,25 @@ const packages = [
     name: 'Diagnostic sprint',
     summary:
       'A three-week assessment that surfaces quick wins, risks, and a prioritised roadmap for change.',
+    relatedCaseStudies: ['payroll-consolidation'],
   },
   {
     name: 'Transformation partner',
     summary:
       'Embedded leadership across delivery squads to guide major platform or process rollouts.',
+    relatedCaseStudies: ['global-hcm-replacement'],
   },
   {
     name: 'Fractional operator',
     summary:
       'Part-time executive support to keep initiatives moving while you hire permanent leadership.',
+    relatedCaseStudies: ['hr-ops-ai-assistant'],
   },
 ]
 
 export default function PackagesPage() {
+  const caseStudyMap = new Map(CASE_STUDIES.map((study) => [study.slug, study]))
+
   return (
     <Section className="py-16">
       <div className="container mx-auto max-w-4xl px-4">
@@ -63,6 +71,26 @@ export default function PackagesPage() {
               >
                 <h2 className="text-2xl font-semibold text-white">{offer.name}</h2>
                 <p className="mt-4 text-sm text-slate-300">{offer.summary}</p>
+                <div className="mt-6 space-y-2 text-sm">
+                  {offer.relatedCaseStudies?.map((slug) => {
+                    const study = caseStudyMap.get(slug)
+
+                    if (!study) return null
+
+                    return (
+                      <p key={slug} className="text-slate-400">
+                        See how we applied this package in{' '}
+                        <Link
+                          href={`/work/${slug}`}
+                          className="font-medium text-sky-300 transition hover:text-sky-200"
+                        >
+                          {study.title}
+                        </Link>{' '}
+                        — {study.resultsSummary}
+                      </p>
+                    )
+                  })}
+                </div>
               </article>
             ))}
           </div>

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from 'next'
 
+import Link from 'next/link'
+
+import { CASE_STUDIES } from '@/app/work/case-studies'
 import { Section } from '@/components/Section'
 
 const title = 'HRIT advisory HR systems audit HR AI PMO services playbooks'
@@ -30,25 +33,31 @@ const services = [
     title: 'Operating model design',
     description:
       'Align roles, systems, and processes around the outcomes that matter most so teams can scale',
+    featuredCaseStudies: ['global-hcm-replacement', 'payroll-consolidation'],
   },
   {
     title: 'Platform implementation leadership',
     description:
       'Navigate ERP, HRIS, or billing deployments with a partner who has led global rollouts before.',
+    featuredCaseStudies: ['global-hcm-replacement'],
   },
   {
     title: 'Process optimisation sprints',
     description:
       'Identify waste, codify best practices, and automate the manual steps that slow delivery.',
+    featuredCaseStudies: ['payroll-consolidation'],
   },
   {
     title: 'Fractional operations support',
     description:
       'Bridge leadership gaps or accelerate change with an embedded, outcomes-focused operator.',
+    featuredCaseStudies: ['hr-ops-ai-assistant'],
   },
 ]
 
 export default function ServicesPage() {
+  const caseStudyMap = new Map(CASE_STUDIES.map((study) => [study.slug, study]))
+
   return (
     <Section className="py-16">
       <div className="container mx-auto max-w-4xl px-4">
@@ -68,6 +77,42 @@ export default function ServicesPage() {
               </div>
             ))}
           </dl>
+
+          <div className="space-y-6 rounded-2xl border border-slate-800 bg-slate-950/40 p-6">
+            <h2 className="text-2xl font-semibold text-white">Related case studies</h2>
+            <p className="text-sm text-slate-300">
+              Explore how these engagements brought each service pillar to life.
+            </p>
+            <div className="space-y-6">
+              {services.map((service) => (
+                <div key={`${service.title}-related`} className="space-y-3">
+                  <h3 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">
+                    {service.title}
+                  </h3>
+                  <ul className="space-y-2">
+                    {service.featuredCaseStudies?.map((slug) => {
+                      const study = caseStudyMap.get(slug)
+
+                      if (!study) return null
+
+                      return (
+                        <li key={slug}>
+                          <Link
+                            href={`/work/${slug}`}
+                            className="inline-flex items-baseline gap-2 text-sm font-medium text-sky-300 transition hover:text-sky-200"
+                          >
+                            <span>{study.title}</span>
+                            <span aria-hidden>→</span>
+                          </Link>
+                          <p className="mt-1 text-xs text-slate-400">{study.resultsSummary}</p>
+                        </li>
+                      )
+                    })}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       </div>
     </Section>

--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -113,7 +113,13 @@ export default function CaseStudyPage({ params }: Params) {
             </dl>
           </div>
           <div className="rounded-3xl border border-[rgba(255,255,255,0.08)] bg-slate-950/40 p-6">
-            <h2 className="text-base font-semibold text-white">Headline outcomes</h2>
+            <h2 id="results" className="text-base font-semibold text-white">
+              Results
+            </h2>
+            <p className="mt-3 text-sm text-slate-300">
+              {study.resultsSummary}{' '}
+              These metrics capture the outcomes delivered through the engagement.
+            </p>
             <ul className="mt-4 grid gap-4 sm:grid-cols-3">
               {study.outcomes.map((outcome) => (
                 <li key={outcome.label} className="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-slate-950/60 p-4">

--- a/app/work/case-studies.ts
+++ b/app/work/case-studies.ts
@@ -2,6 +2,7 @@ export type CaseStudy = {
   slug: string
   title: string
   summary: string
+  resultsSummary: string
   seoTitle: string
   seoDescription: string
   hero: {
@@ -37,6 +38,8 @@ export const CASE_STUDIES: CaseStudy[] = [
     slug: 'global-hcm-replacement',
     title: 'Global HCM replacement',
     summary: 'Vendor selection and readiness for 40k employees.',
+    resultsSummary:
+      'Unified seven regional HR stacks into a single HCM blueprint, unlocking measurable savings, cleaner data, and faster rollouts.',
     seoTitle: 'HRIT advisory HR systems audit HR AI PMO global scale',
     seoDescription:
       'See HRIT advisory direction with HR systems audit rigor, HR AI exploration, and PMO governance combine to unify a hospitality group\'s global HCM landscape.',
@@ -95,6 +98,8 @@ export const CASE_STUDIES: CaseStudy[] = [
     slug: 'payroll-consolidation',
     title: 'Payroll consolidation',
     summary: '12-country integration and control framework.',
+    resultsSummary:
+      'Delivered a consolidated payroll control framework that shrank errors, accelerated onboarding, and tightened financial reporting.',
     seoTitle: 'HRIT advisory HR systems audit HR AI PMO payroll unity',
     seoDescription:
       'Watch HRIT advisory guidance, HR systems audit structure, HR AI experimentation, and PMO cadence consolidate payroll operations into a control framework.',
@@ -148,6 +153,8 @@ export const CASE_STUDIES: CaseStudy[] = [
     slug: 'hr-ops-ai-assistant',
     title: 'HR Ops AI assistant',
     summary: 'Reduced resolution time by 34%.',
+    resultsSummary:
+      'Combined AI guardrails with knowledge modernisation so HR agents could resolve tickets faster and lift service satisfaction.',
     seoTitle: 'HRIT advisory HR systems audit HR AI PMO assistant win',
     seoDescription:
       'Follow how HRIT advisory prioritisation, HR systems audit cleanup, HR AI guardrails, and PMO coaching delivered a compliant assistant that shrank handle times.',


### PR DESCRIPTION
## Summary
- add narrative results summaries to case studies and use them to clarify the results section on individual pages
- surface related case study links beneath each services pillar
- point each package toward a detailed case study for deeper context

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfbfb20bb08330ae06ca8d92b39eb3