### PR TITLE
Add newsletter subscription API endpoint and form handling

### DIFF
--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const newsletterSchema = z.object({
+  email: z
+    .string({ required_error: 'Email is required.' })
+    .trim()
+    .min(1, 'Email is required.')
+    .email('Please provide a valid email address.'),
+});
+
+export async function POST(request: Request): Promise<Response> {
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json(
+      { ok: false, message: 'Invalid JSON payload.' },
+      { status: 400 },
+    );
+  }
+
+  const result = newsletterSchema.safeParse(payload);
+
+  if (!result.success) {
+    const [firstError] = result.error.issues;
+    return NextResponse.json(
+      {
+        ok: false,
+        message: firstError?.message ?? 'Please provide a valid email address.',
+      },
+      { status: 400 },
+    );
+  }
+
+  const { email } = result.data;
+
+  // TODO: Replace this log with integration to the selected ESP provider.
+  console.info('Newsletter subscription received', { email });
+
+  return NextResponse.json({ ok: true });
+}

--- a/components/NewsletterForm.tsx
+++ b/components/NewsletterForm.tsx
@@ -33,8 +33,10 @@ export function NewsletterForm({ className }: NewsletterFormProps) {
       })
 
       const payload = await response.json().catch(() => null)
+      const payloadOk =
+        payload && typeof payload.ok === 'boolean' ? payload.ok : response.ok
 
-      if (!response.ok) {
+      if (!payloadOk) {
         const message =
           (payload && typeof payload.message === 'string' && payload.message) ||
           'Something went wrong. Please try again.'
@@ -46,7 +48,8 @@ export function NewsletterForm({ className }: NewsletterFormProps) {
 
       setStatus('success')
       setFeedback(
-        (payload && typeof payload.message === 'string' && payload.message) || 'Thanks for subscribing! We will be in touch soon.'
+        (payload && typeof payload.message === 'string' && payload.message) ||
+          'Thanks for subscribing! We will be in touch soon.'
       )
       setEmail('')
     } catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "rehype-autolink-headings": "^7.0.0",
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.0",
-        "resend": "^6.1.2"
+        "resend": "^6.1.2",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.15",
@@ -15012,6 +15013,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "node": "22.x"
   },
   "dependencies": {
-    "@next/mdx": "14.2.5",
     "@mdx-js/loader": "^2.3.0",
     "@mdx-js/react": "^2.3.0",
+    "@next/mdx": "14.2.5",
     "framer-motion": "^11.0.0",
     "lucide-react": "^0.468.0",
     "next": "14.2.5",
@@ -24,19 +24,20 @@
     "rehype-autolink-headings": "^7.0.0",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.0",
-    "resend": "^6.1.2"
+    "resend": "^6.1.2",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.20",
-    "postcss": "^8.4.41",
-    "tailwindcss": "^3.4.13",
     "@tailwindcss/typography": "^0.5.15",
-    "typescript": "^5.6.2",
     "@types/node": "^20.14.9",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
+    "autoprefixer": "^10.4.20",
     "eslint": "^8.57.0",
     "eslint-config-next": "14.2.5",
+    "postcss": "^8.4.41",
+    "tailwindcss": "^3.4.13",
+    "typescript": "^5.6.2",
     "vitest": "^3.2.4"
   }
 }


### PR DESCRIPTION
## Summary
- add a newsletter POST route with Zod validation and placeholder ESP integration
- update the newsletter form to respect the API response `ok` flag and surface messages
- add the Zod dependency for schema validation in the new route

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e009eb9d808330a1f4e8e9ea59ec24