### PR TITLE
Add dynamic Open Graph images for blog posts

### DIFF
--- a/app/blog/[slug]/opengraph-image.tsx
+++ b/app/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,27 @@
+import { createBlogOgImage } from '@/lib/blog-og-image'
+import { OG_IMAGE_SIZE } from '@/lib/og-image'
+
+import { POSTS } from '../posts'
+
+export const runtime = 'edge'
+export const size = OG_IMAGE_SIZE
+export const alt = 'Icarius Insights blog article artwork'
+export const contentType = 'image/png'
+
+type OgImageProps = {
+  params: {
+    slug: string
+  }
+}
+
+export default function Image({ params }: OgImageProps) {
+  const slug = params.slug
+  const post = POSTS.find(entry => entry.slug === slug)
+
+  const title = post?.title ?? 'Icarius Insights'
+  const tagline = post?.tags?.length
+    ? post.tags.join(' • ')
+    : 'HR transformation perspectives from Icarius Consulting'
+
+  return createBlogOgImage({ title, tagline })
+}

--- a/app/blog/ai-readiness-for-hr/page.mdx
+++ b/app/blog/ai-readiness-for-hr/page.mdx
@@ -4,6 +4,19 @@ export const metadata = {
     'Pragmatic steps HR teams can take to prepare data, governance, and people for responsible AI pilots.',
   date: '2024-09-18',
   tags: ['AI', 'HR', 'Change'],
+  openGraph: {
+    url: '/blog/ai-readiness-for-hr',
+    images: [
+      { url: '/blog/ai-readiness-for-hr/opengraph-image', width: 1200, height: 630 },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    url: '/blog/ai-readiness-for-hr',
+    images: [
+      { url: '/blog/ai-readiness-for-hr/opengraph-image', width: 1200, height: 630 },
+    ],
+  },
 }
 
 import { ArticleJsonLd } from '@/components/ArticleJsonLd'

--- a/app/blog/delivery-jumpstart-30-days/page.mdx
+++ b/app/blog/delivery-jumpstart-30-days/page.mdx
@@ -4,6 +4,19 @@ export const metadata = {
     'A 30-day plan to stabilise in-flight transformations, build trust with sponsors, and deliver tangible HRIT outcomes fast.',
   date: '2024-10-22',
   tags: ['Delivery', 'PMO', 'Transformation'],
+  openGraph: {
+    url: '/blog/delivery-jumpstart-30-days',
+    images: [
+      { url: '/blog/delivery-jumpstart-30-days/opengraph-image', width: 1200, height: 630 },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    url: '/blog/delivery-jumpstart-30-days',
+    images: [
+      { url: '/blog/delivery-jumpstart-30-days/opengraph-image', width: 1200, height: 630 },
+    ],
+  },
 }
 
 import { ArticleJsonLd } from '@/components/ArticleJsonLd'

--- a/app/blog/hris-audit-sprint-playbook/page.mdx
+++ b/app/blog/hris-audit-sprint-playbook/page.mdx
@@ -4,6 +4,19 @@ export const metadata = {
     'A step-by-step sprint model for auditing HR platforms, surfacing risk, and mapping remediation work in under six weeks.',
   date: '2024-11-05',
   tags: ['HRIS', 'Audit', 'Governance'],
+  openGraph: {
+    url: '/blog/hris-audit-sprint-playbook',
+    images: [
+      { url: '/blog/hris-audit-sprint-playbook/opengraph-image', width: 1200, height: 630 },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    url: '/blog/hris-audit-sprint-playbook',
+    images: [
+      { url: '/blog/hris-audit-sprint-playbook/opengraph-image', width: 1200, height: 630 },
+    ],
+  },
 }
 
 import { ArticleJsonLd } from '@/components/ArticleJsonLd'

--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -17,13 +17,13 @@ export const metadata: Metadata = {
     title: defaultTitle,
     description: defaultDescription,
     url: '/blog',
-    images: [{ url: '/opengraph-image', width: 1200, height: 630 }],
+    images: [{ url: '/blog/opengraph-image', width: 1200, height: 630 }],
   },
   twitter: {
     card: 'summary_large_image',
     title: defaultTitle,
     description: defaultDescription,
-    images: [{ url: '/twitter-image', width: 1200, height: 630 }],
+    images: [{ url: '/blog/opengraph-image', width: 1200, height: 630 }],
   },
   robots: { index: true, follow: true },
 }

--- a/app/blog/opengraph-image.tsx
+++ b/app/blog/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { createBlogOgImage } from '@/lib/blog-og-image'
+import { OG_IMAGE_SIZE } from '@/lib/og-image'
+
+export const runtime = 'edge'
+export const size = OG_IMAGE_SIZE
+export const alt = 'Icarius Insights — Icarius Consulting blog overview'
+export const contentType = 'image/png'
+
+export default function Image() {
+  return createBlogOgImage({
+    title: 'Icarius Insights',
+    tagline: 'HR transformation, delivery, and AI guidance from Icarius Consulting',
+  })
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -15,13 +15,13 @@ export const metadata: Metadata = {
     title,
     description,
     url: '/blog',
-    images: [{ url: '/opengraph-image', width: 1200, height: 630 }],
+    images: [{ url: '/blog/opengraph-image', width: 1200, height: 630 }],
   },
   twitter: {
     card: 'summary_large_image',
     title,
     description,
-    images: [{ url: '/twitter-image', width: 1200, height: 630 }],
+    images: [{ url: '/blog/opengraph-image', width: 1200, height: 630 }],
   },
   robots: { index: true, follow: true },
 }

--- a/app/blog/roi-of-hr-automation/page.mdx
+++ b/app/blog/roi-of-hr-automation/page.mdx
@@ -4,6 +4,19 @@ export const metadata = {
     'A pragmatic framework for quantifying the financial and experience gains from automating HR operations.',
   date: '2024-08-28',
   tags: ['Automation', 'ROI', 'HR Operations'],
+  openGraph: {
+    url: '/blog/roi-of-hr-automation',
+    images: [
+      { url: '/blog/roi-of-hr-automation/opengraph-image', width: 1200, height: 630 },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    url: '/blog/roi-of-hr-automation',
+    images: [
+      { url: '/blog/roi-of-hr-automation/opengraph-image', width: 1200, height: 630 },
+    ],
+  },
 }
 
 import { ArticleJsonLd } from '@/components/ArticleJsonLd'

--- a/lib/blog-og-image.tsx
+++ b/lib/blog-og-image.tsx
@@ -1,0 +1,107 @@
+import { ImageResponse } from 'next/og'
+
+import { OG_IMAGE_SIZE } from './og-image'
+
+type BlogOgImageOptions = {
+  title: string
+  tagline: string
+}
+
+const baseHeaders = {
+  'content-type': 'image/png',
+  'cache-control': 'public, immutable, no-transform, max-age=86400',
+}
+
+export function createBlogOgImage({ title, tagline }: BlogOgImageOptions) {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          position: 'relative',
+          padding: '72px',
+          color: '#E8ECF8',
+          backgroundColor: '#070b18',
+          backgroundImage:
+            'radial-gradient(circle at 20% 12%, rgba(107,140,255,0.22), transparent 60%), radial-gradient(circle at 82% 88%, rgba(142,235,255,0.16), transparent 65%), linear-gradient(180deg, #070b18 0%, #0b1020 52%, #070b18 100%)',
+          fontFamily: 'Inter, "Segoe UI", sans-serif',
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            inset: '40px',
+            borderRadius: '44px',
+            border: '1px solid rgba(255,255,255,0.08)',
+          }}
+        />
+
+        <div style={{ position: 'relative', display: 'flex', flexDirection: 'column', gap: '28px', maxWidth: '900px' }}>
+          <span
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '10px',
+              padding: '12px 22px',
+              borderRadius: '999px',
+              backgroundColor: 'rgba(107,140,255,0.16)',
+              color: '#8eebff',
+              fontSize: '26px',
+              fontWeight: 600,
+              letterSpacing: '0.04em',
+              textTransform: 'uppercase',
+              width: 'fit-content',
+            }}
+          >
+            Icarius Insights
+          </span>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            <h1
+              style={{
+                fontSize: '72px',
+                fontWeight: 700,
+                letterSpacing: '-0.02em',
+                lineHeight: 1.1,
+              }}
+            >
+              {title}
+            </h1>
+            <p
+              style={{
+                fontSize: '32px',
+                color: '#B6BFDB',
+                lineHeight: 1.4,
+                margin: 0,
+              }}
+            >
+              {tagline}
+            </p>
+          </div>
+        </div>
+
+        <div
+          style={{
+            position: 'relative',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            fontSize: '28px',
+            color: 'rgba(230,234,248,0.85)',
+          }}
+        >
+          <span style={{ fontWeight: 600 }}>icarius-consulting.com</span>
+          <span style={{ color: '#8eebff' }}>HR Transformation Partners</span>
+        </div>
+      </div>
+    ),
+    {
+      ...OG_IMAGE_SIZE,
+      headers: baseHeaders,
+    }
+  )
+}


### PR DESCRIPTION
## Summary
- add shared Icarius Insights Open Graph image renderer and default blog image route
- create dynamic Open Graph route for blog posts that surfaces each article title and tag line
- extend blog metadata to reference the new artwork for the index page and individual posts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e02f8a84088330943960104a01bb51