### PR TITLE
Update CSP to allow Mailjet API connections

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -23,7 +23,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://www.googletagmanager.com https://www.google-analytics.com; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com; frame-src 'self' https://calendly.com https://*.calendly.com https://cal.com https://*.cal.com"
+          "value": "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://www.googletagmanager.com https://www.google-analytics.com; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com https://api.mailjet.com; frame-src 'self' https://calendly.com https://*.calendly.com https://cal.com https://*.cal.com"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add the Mailjet API domain to the Content-Security-Policy connect-src directive
- keep existing analytics and embed directives unchanged while maintaining CSP formatting

## Testing
- node -e "const fs=require('fs');const data=JSON.parse(fs.readFileSync('vercel.json','utf8'));const csp=data.headers[0].headers.find(h=>h.key==='Content-Security-Policy').value;console.log(csp);"

------
https://chatgpt.com/codex/tasks/task_e_68e031830984833081303e7aa9be9477