### PR TITLE
Use global header on blog pages

### DIFF
--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next'
 import type { ReactNode } from 'react'
 
-import { Header } from '@/components/header'
 
 const defaultTitle = 'HRIT advisory HR systems audit HR AI PMO insights library'
 const defaultDescription =
@@ -31,7 +30,6 @@ export const metadata: Metadata = {
 export default function BlogLayout({ children }: { children: ReactNode }) {
   return (
     <>
-      <Header />
       <div className="prose prose-invert mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
         {children}
       </div>


### PR DESCRIPTION
## Summary
- remove the blog layout header import and rely on the global layout header instead

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e037e15e1c833088b8e2d36c333e1b