### PR TITLE
Lazy load contact modal trigger for book CTA

### DIFF
--- a/components/BookCTA.tsx
+++ b/components/BookCTA.tsx
@@ -1,9 +1,16 @@
 'use client'
 
-import { forwardRef } from 'react'
+import dynamic from 'next/dynamic'
+import { forwardRef, useEffect, useState } from 'react'
 import type { AnchorHTMLAttributes } from 'react'
 
 import { buildBookingUrl } from '@/lib/booking'
+import type { ContactModalTriggerProps } from './ContactModal'
+
+const ContactModalTrigger = dynamic<ContactModalTriggerProps>(
+  () => import('@/components/ContactModal').then((m) => m.ContactModalTrigger),
+  { ssr: false },
+)
 
 export type BookCTAProps = {
   plan?: string
@@ -13,15 +20,37 @@ export const BookCTA = forwardRef<HTMLAnchorElement, BookCTAProps>(
   ({ plan, children = 'Book a call', target = '_blank', rel, ...props }, ref) => {
     const href = buildBookingUrl(plan)
     const computedRel = rel ?? (target === '_blank' ? 'noopener noreferrer' : undefined)
+    const [triggerReady, setTriggerReady] = useState(false)
+
+    useEffect(() => {
+      let isMounted = true
+
+      import('@/components/ContactModal').then(() => {
+        if (isMounted) {
+          setTriggerReady(true)
+        }
+      })
+
+      return () => {
+        isMounted = false
+      }
+    }, [])
+
+    if (triggerReady) {
+      return (
+        <ContactModalTrigger
+          {...props}
+          plan={plan}
+          target={target}
+          rel={computedRel}
+        >
+          {children}
+        </ContactModalTrigger>
+      )
+    }
 
     return (
-      <a
-        {...props}
-        ref={ref}
-        href={href}
-        target={target}
-        rel={computedRel}
-      >
+      <a {...props} ref={ref} href={href} target={target} rel={computedRel}>
         {children}
       </a>
     )

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -80,7 +80,7 @@ type ContactModalTriggerBaseProps = {
   plan?: string
   cta?: string
   children?: ReactNode
-} & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'target' | 'rel'>
+} & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>
 
 export type ContactModalTriggerProps = ContactModalTriggerBaseProps
 
@@ -90,12 +90,15 @@ export function ContactModalTrigger({
   children = 'Book a call',
   className,
   onClick,
+  target,
+  rel,
   ...rest
 }: ContactModalTriggerProps) {
   const href = buildBookingUrl(plan)
   const dataPlan = plan ?? 'general'
   const triggerRef = useRef<HTMLAnchorElement | null>(null)
   const [modalOpen, setModalOpen] = useState(false)
+  const anchorRel = rel ?? (target === '_blank' ? 'noopener noreferrer' : undefined)
 
   const closeModal = useCallback(() => {
     setModalOpen(false)
@@ -142,6 +145,8 @@ export function ContactModalTrigger({
         ref={triggerRef}
         className={className}
         href={href}
+        target={target}
+        rel={anchorRel}
         data-cta={cta}
         data-plan={dataPlan}
         onClick={handleClick}


### PR DESCRIPTION
## Summary
- lazy load the ContactModal trigger inside the BookCTA component while preserving the server-rendered anchor fallback
- allow the ContactModalTrigger to receive target/rel attributes so analytics and link behavior remain consistent after hydration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e03d258a908330b16b2ab0ddba3f11