### PR TITLE
Sync blog post listings with available MDX pages

### DIFF
--- a/app/blog/posts.ts
+++ b/app/blog/posts.ts
@@ -24,44 +24,12 @@ export const POSTS: Post[] = [
     tags: ['Delivery', 'PMO', 'Transformation'],
   },
   {
-    slug: 'modernizing-hr-service-delivery-analytics',
-    title: 'Modernizing HR Service Delivery with Analytics',
-    summary:
-      'Analytics-led operating reviews surface backlog root causes and clear the path to better employee experience.',
-    date: '2024-10-24',
-    tags: ['Analytics', 'Service Delivery'],
-  },
-  {
-    slug: 'pmo-sprints-for-global-hr-transformations',
-    title: 'PMO Sprints for Global HR Transformations',
-    summary:
-      'Break large HR programs into accountable sprints to accelerate delivery without losing executive trust.',
-    date: '2024-10-03',
-    tags: ['PMO', 'Transformation'],
-  },
-  {
     slug: 'ai-readiness-for-hr',
     title: 'AI Readiness for HR',
     summary:
       'Prepare HR data, governance, and teams for responsible AI pilots that balance innovation with compliance.',
     date: '2024-09-18',
     tags: ['AI', 'HR', 'Change'],
-  },
-  {
-    slug: 'ai-change-management-playbook-for-people-teams',
-    title: 'An AI Change Management Playbook for People Teams',
-    summary:
-      'Tactics to de-risk AI pilots with cross-functional governance, data readiness, and workforce enablement.',
-    date: '2024-09-12',
-    tags: ['AI', 'Change Management'],
-  },
-  {
-    slug: 'aligning-hrit-roadmaps-with-business-outcomes',
-    title: 'Aligning HRIT Roadmaps with Business Outcomes',
-    summary:
-      'Use value-stream prioritization to focus HR technology roadmaps on measurable enterprise OKRs.',
-    date: '2024-08-20',
-    tags: ['HRIT', 'Strategy'],
   },
   {
     slug: 'roi-of-hr-automation',


### PR DESCRIPTION
## Summary
- remove unpublished slugs from the blog post registry so the index and RSS feed only reference MDX content that exists

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e040a708708330a31c5f18dd4d6a3f