### PR TITLE
Allow Mailjet API in CSP connect-src

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -39,7 +39,7 @@ const nextConfig = {
           {
             key: 'Content-Security-Policy',
             value:
-              "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://www.googletagmanager.com https://www.google-analytics.com; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com; frame-src 'self' https://calendly.com https://*.calendly.com https://cal.com https://*.cal.com",
+              "default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://www.googletagmanager.com https://www.google-analytics.com; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com https://api.mailjet.com; frame-src 'self' https://calendly.com https://*.calendly.com https://cal.com https://*.cal.com",
           },
         ],
       },


### PR DESCRIPTION
## Summary
- align the Next.js Content-Security-Policy connect-src directive with Vercel configuration
- allow requests to https://api.mailjet.com so newsletter submissions are not blocked

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e042135c5483309f2d3685f977aac1