### PR TITLE
Centralize site origin configuration

### DIFF
--- a/app/blog/rss/route.ts
+++ b/app/blog/rss/route.ts
@@ -1,6 +1,6 @@
-import { POSTS } from '../posts'
+import { siteOrigin } from '@/lib/config/site'
 
-const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000').replace(/\/$/, '')
+import { POSTS } from '../posts'
 
 const escapeXml = (value: string) =>
   value
@@ -12,7 +12,7 @@ const escapeXml = (value: string) =>
 
 const buildFeed = () => {
   const items = POSTS.map((post) => {
-    const postUrl = `${SITE_URL}/blog/${post.slug}`
+    const postUrl = `${siteOrigin}/blog/${post.slug}`
     const pubDate = new Date(post.date).toUTCString()
 
     return `    <item>\n` +
@@ -29,7 +29,7 @@ const buildFeed = () => {
     '<rss version="2.0">',
     '  <channel>',
     '    <title>Icarius Blog</title>',
-    `    <link>${SITE_URL}/blog</link>`,
+    `    <link>${siteOrigin}/blog</link>`,
     '    <description>Latest posts from the Icarius blog.</description>',
     '    <language>en-US</language>',
     `    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>`,

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,26 +1,9 @@
 import type { MetadataRoute } from 'next'
 
-const FALLBACK_SITE_URL = 'https://www.icarius-consulting.com'
-
-function resolveSiteUrl() {
-  const configuredSiteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? FALLBACK_SITE_URL
-  const normalisedInput = configuredSiteUrl.endsWith('/')
-    ? configuredSiteUrl.slice(0, -1)
-    : configuredSiteUrl
-
-  try {
-    return new URL(normalisedInput).origin
-  } catch {
-    try {
-      return new URL(`https://${normalisedInput}`).origin
-    } catch {
-      return FALLBACK_SITE_URL
-    }
-  }
-}
+import { resolveSiteOrigin } from '@/lib/config/site'
 
 export default function robots(): MetadataRoute.Robots {
-  const siteUrl = resolveSiteUrl()
+  const siteUrl = resolveSiteOrigin()
 
   return {
     rules: {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,29 +1,12 @@
 import type { MetadataRoute } from 'next'
 
+import { resolveSiteOrigin } from '@/lib/config/site'
+
 import { CASE_STUDIES } from './work/case-studies'
 import { POSTS } from './blog/posts'
 
-const FALLBACK_SITE_URL = 'https://www.icarius-consulting.com'
-
-function resolveSiteUrl() {
-  const configuredSiteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? FALLBACK_SITE_URL
-  const normalisedInput = configuredSiteUrl.endsWith('/')
-    ? configuredSiteUrl.slice(0, -1)
-    : configuredSiteUrl
-
-  try {
-    return new URL(normalisedInput).origin
-  } catch {
-    try {
-      return new URL(`https://${normalisedInput}`).origin
-    } catch {
-      return FALLBACK_SITE_URL
-    }
-  }
-}
-
 export default function sitemap(): MetadataRoute.Sitemap {
-  const siteUrl = resolveSiteUrl()
+  const siteUrl = resolveSiteOrigin()
 
   const staticRoutes = [
     '/',

--- a/lib/config/site.test.ts
+++ b/lib/config/site.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const setEnv = (value: string | undefined) => {
+  if (typeof value === 'string') {
+    process.env.NEXT_PUBLIC_SITE_URL = value
+  } else {
+    delete process.env.NEXT_PUBLIC_SITE_URL
+  }
+}
+
+describe('resolveSiteOrigin', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_SITE_URL
+
+  afterEach(() => {
+    setEnv(originalEnv)
+    vi.resetModules()
+  })
+
+  it('normalizes the configured site URL when present', async () => {
+    vi.resetModules()
+    setEnv('https://example.com/')
+
+    const { resolveSiteOrigin } = await import('./site')
+
+    expect(resolveSiteOrigin()).toBe('https://example.com')
+  })
+
+  it('derives an origin when the scheme is omitted', async () => {
+    vi.resetModules()
+    setEnv('example.com/blog')
+
+    const { resolveSiteOrigin } = await import('./site')
+
+    expect(resolveSiteOrigin()).toBe('https://example.com')
+  })
+
+  it('falls back to the default when the env value is empty', async () => {
+    vi.resetModules()
+    setEnv('   ')
+
+    const { defaultSiteUrl, resolveSiteOrigin } = await import('./site')
+
+    expect(resolveSiteOrigin()).toBe(defaultSiteUrl)
+  })
+
+  it('falls back to the default when the env value is invalid', async () => {
+    vi.resetModules()
+    setEnv('http://exa mple.com')
+
+    const { defaultSiteUrl, resolveSiteOrigin } = await import('./site')
+
+    expect(resolveSiteOrigin()).toBe(defaultSiteUrl)
+  })
+
+  it('exposes a shared siteOrigin constant', async () => {
+    vi.resetModules()
+    setEnv('https://shared.example/')
+
+    const { resolveSiteOrigin, siteOrigin } = await import('./site')
+
+    expect(siteOrigin).toBe('https://shared.example')
+    expect(siteOrigin).toBe(resolveSiteOrigin())
+  })
+})

--- a/lib/config/site.ts
+++ b/lib/config/site.ts
@@ -1,0 +1,43 @@
+const FALLBACK_SITE_URL = 'https://www.icarius-consulting.com'
+
+const sanitizeUrl = (value: string | undefined): string => {
+  if (!value) return FALLBACK_SITE_URL
+
+  const trimmed = value.trim()
+  if (!trimmed) return FALLBACK_SITE_URL
+
+  let candidate = trimmed
+  while (candidate.endsWith('/')) {
+    candidate = candidate.slice(0, -1)
+  }
+
+  const tryParse = (input: string): string | null => {
+    try {
+      return new URL(input).origin
+    } catch {
+      return null
+    }
+  }
+
+  const origin = tryParse(candidate)
+  if (origin) {
+    return origin
+  }
+
+  if (!/^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(candidate)) {
+    const prefixedOrigin = tryParse(`https://${candidate}`)
+    if (prefixedOrigin) {
+      return prefixedOrigin
+    }
+  }
+
+  return FALLBACK_SITE_URL
+}
+
+export const resolveSiteOrigin = (
+  rawValue: string | undefined = process.env.NEXT_PUBLIC_SITE_URL,
+): string => sanitizeUrl(rawValue)
+
+export const siteOrigin = resolveSiteOrigin()
+
+export { FALLBACK_SITE_URL as defaultSiteUrl }


### PR DESCRIPTION
## Summary
- add a shared site origin helper with fallback and normalization logic
- update RSS, robots, and sitemap routes to consume the centralized origin value
- cover environment edge cases for the helper with new Vitest specs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e04429be708330b2f044c6d3e0c7f8