### PR TITLE
Ensure newsletter feedback uses persistent status region

### DIFF
--- a/components/NewsletterForm.tsx
+++ b/components/NewsletterForm.tsx
@@ -69,6 +69,14 @@ export function NewsletterForm({ className }: NewsletterFormProps) {
     .filter(Boolean)
     .join(' ')
 
+  const feedbackClassName = `text-xs ${
+    status === 'success'
+      ? 'text-emerald-300'
+      : status === 'error'
+        ? 'text-red-300'
+        : 'text-slate-300'
+  }`
+
   return (
     <form className={formClasses} onSubmit={handleSubmit} noValidate>
       <label className="relative flex-1">
@@ -91,19 +99,14 @@ export function NewsletterForm({ className }: NewsletterFormProps) {
       >
         {buttonLabel}
       </button>
-      {feedback && (
-        <p
-          className={`text-xs ${
-            status === 'success'
-              ? 'text-emerald-300'
-              : status === 'error'
-                ? 'text-red-300'
-                : 'text-slate-300'
-          }`}
-        >
-          {feedback}
-        </p>
-      )}
+      <p
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className={feedbackClassName}
+      >
+        {feedback ?? ''}
+      </p>
     </form>
   )
 }


### PR DESCRIPTION
## Summary
- keep the newsletter feedback element mounted at all times with ARIA live status semantics
- continue to style feedback messages based on success, error, or neutral status while emitting empty text when no message is present

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e04837a1448330b1618e583c56eafc