### PR TITLE
Add ChatWidget to global layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import '@/styles/globals.css'
 import { SiteProviders } from '@/components/consent-provider'
 import { Header } from '@/components/header'
 import { Footer } from '@/components/footer'
+import { ChatWidget } from '@/components/ChatWidget'
 import { inter } from '@/app/fonts'
 import { ViewObserver } from '@/app/providers'
 import { siteOrigin } from '@/lib/config/site'
@@ -83,6 +84,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             {children}
           </main>
           <Footer />
+          <ChatWidget />
         </SiteProviders>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- import the ChatWidget component into the root layout
- render the ChatWidget within SiteProviders after the footer so it appears on every page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e455114ab88330ac4d7be633746ef8