### PR TITLE
Add accessible label to chat widget input

### DIFF
--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -379,8 +379,12 @@ export function ChatWidget() {
       </div>
 
       <form onSubmit={handleSubmit} className="flex gap-2">
+        <label htmlFor="chat-widget-message" className="sr-only">
+          Message Icarius Assistant
+        </label>
         <input
           type="text"
+          id="chat-widget-message"
           value={input}
           onChange={(event) => setInput(event.target.value)}
           placeholder="Type a message"


### PR DESCRIPTION
## Summary
- add a visually hidden label describing the chat message input
- connect the label to the input to improve assistive technology support

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e45a8b1af4833095d133003b6c88f1