### PR TITLE
Anchor chat widget to viewport

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -80,11 +80,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <a href="#main" className="skip-link">Skip to content</a>
         <SiteProviders>
           <Header />
-          <main id="main" tabIndex={-1} className="container mx-auto px-4">
+          <main id="main" tabIndex={-1} className="container mx-auto px-4 pb-32">
             {children}
           </main>
           <Footer />
-          <ChatWidget />
+          <div className="pointer-events-auto fixed bottom-6 right-6 z-50 w-full max-w-sm">
+            <ChatWidget />
+          </div>
         </SiteProviders>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- wrap the chat widget in a fixed-position container so it stays anchored to the viewport
- add bottom padding to the main content to prevent overlap with the fixed widget

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e45f178d348330b973295f4be03f2d