### PR TITLE
Refactor global background layering

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -57,16 +57,26 @@
   }
 }
 
-html, body {
-  /* fallback */
+html {
   background-color: var(--bg);
-  /* layered, subtle glow + vertical wash */
-  background:
+}
+
+body {
+  color: var(--text);
+  position: relative;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: -1;
+  background-color: var(--bg);
+  background-image:
     radial-gradient(900px 600px at 20% -10%, rgba(107,140,255,0.08), transparent 40%),
     radial-gradient(800px 500px at 80% 110%, rgba(142,235,255,0.06), transparent 42%),
     linear-gradient(180deg, #070b18, var(--bg) 30%, var(--bg) 70%, #070b18);
-  color: var(--text);
-  background-attachment: fixed;
 }
 .container {
   max-width: 1100px;


### PR DESCRIPTION
## Summary
- move the global gradient background into a fixed body::before layer instead of using background-attachment: fixed
- preserve the original gradient stack and fallback color while keeping text color on the body

## Testing
- npm run dev


------
https://chatgpt.com/codex/tasks/task_e_68e475d506f48330a2e31d9541ebaf5a