### PR TITLE
Adjust go back button indentation

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -31,7 +31,7 @@ export default function AboutPage() {
     <Section className="py-16">
       <div className="container mx-auto max-w-3xl px-4">
         <div className="mb-6">
-          <div className="ml-8 mb-2">
+          <div className="-ml-2 mb-2">
             <ConditionalGoBackButton />
           </div>
           <h1 className="text-4xl font-semibold tracking-tight">About Icarius Consulting</h1>

--- a/app/accessibility/page.tsx
+++ b/app/accessibility/page.tsx
@@ -31,7 +31,7 @@ export default function AccessibilityPage() {
     <Section className="py-12">
       <div className="prose prose-invert max-w-3xl mx-auto">
         <div className="mb-6 not-prose">
-          <div className="ml-8 mb-2">
+          <div className="-ml-2 mb-2">
             <ConditionalGoBackButton />
           </div>
           <h1 className="text-4xl font-semibold tracking-tight m-0">Accessibility statement</h1>

--- a/app/blog/blog-index.tsx
+++ b/app/blog/blog-index.tsx
@@ -60,7 +60,7 @@ export function BlogIndex({ posts, heading, description }: BlogIndexProps) {
     <div className="not-prose">
       <Section className="py-12">
         <div className="mb-6">
-          <div className="ml-8 mb-2">
+          <div className="-ml-2 mb-2">
             <ConditionalGoBackButton />
           </div>
         </div>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -51,7 +51,7 @@ export default function ContactPage() {
     <Section className="py-16">
       <div className="container mx-auto max-w-3xl px-4">
         <div className="mb-6">
-          <div className="ml-8 mb-2">
+          <div className="-ml-2 mb-2">
             <ConditionalGoBackButton />
           </div>
           <h1 className="text-4xl font-semibold tracking-tight">Contact</h1>

--- a/app/packages/page.tsx
+++ b/app/packages/page.tsx
@@ -57,7 +57,7 @@ export default function PackagesPage() {
     <Section className="py-16">
       <div className="container mx-auto max-w-4xl px-4">
         <div className="mb-6">
-          <div className="ml-8 mb-2">
+          <div className="-ml-2 mb-2">
             <ConditionalGoBackButton />
           </div>
           <h1 className="text-4xl font-semibold tracking-tight">Packages</h1>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -31,7 +31,7 @@ export default function PrivacyPage() {
     <Section className="py-12">
       <div className="prose prose-invert max-w-3xl mx-auto">
         <div className="mb-6 not-prose">
-          <div className="ml-8 mb-2">
+          <div className="-ml-2 mb-2">
             <ConditionalGoBackButton />
           </div>
           <h1 className="text-4xl font-semibold tracking-tight m-0">Privacy policy</h1>

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -63,7 +63,7 @@ export default function ServicesPage() {
     <Section className="py-16">
       <div className="container mx-auto max-w-4xl px-4">
         <div className="mb-6">
-          <div className="ml-8 mb-2">
+          <div className="-ml-2 mb-2">
             <ConditionalGoBackButton />
           </div>
           <h1 className="text-4xl font-semibold tracking-tight">Services</h1>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -31,7 +31,7 @@ export default function TermsPage() {
     <Section className="py-12">
       <div className="prose prose-invert max-w-3xl mx-auto">
         <div className="mb-6 not-prose">
-          <div className="ml-8 mb-2">
+          <div className="-ml-2 mb-2">
             <ConditionalGoBackButton />
           </div>
           <h1 className="text-4xl font-semibold tracking-tight m-0">Terms of service</h1>

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -34,7 +34,7 @@ export default function WorkPage() {
       <div className="container mx-auto px-4 md:px-6">
         <div className="mx-auto max-w-3xl">
           <div className="mb-6 text-center">
-            <div className="ml-8 mb-2 flex justify-center">
+            <div className="-ml-2 mb-2 flex justify-center">
               <ConditionalGoBackButton />
             </div>
             <p className="text-sm font-medium uppercase tracking-[0.2em] text-sky-300/80">Selected work</p>


### PR DESCRIPTION
## Summary
- update the go back button wrapper margin on static pages so it sits slightly to the left of the associated page titles

## Testing
- npm run dev *(fails: optimization.usedExports can't be used with cacheUnaffected)*

------
https://chatgpt.com/codex/tasks/task_e_68e59964a86883309e5ecbaaf501fbef