### PR TITLE
Use generated SVG avatars for testimonials

### DIFF
--- a/components/TestimonialCard.tsx
+++ b/components/TestimonialCard.tsx
@@ -1,0 +1,51 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { createInitialsAvatar } from "@/lib/avatar";
+
+export type Testimonial = {
+  quote: string;
+  author: string;
+  role?: string;
+  href?: string;
+  avatarSrc?: string;
+};
+
+export default function TestimonialCard({ quote, author, role, href, avatarSrc }: Testimonial) {
+  const avatarUrl = avatarSrc ?? createInitialsAvatar(author);
+
+  return (
+    <figure className="rounded-2xl border p-6 shadow-sm bg-white/70 dark:bg-zinc-900/60">
+      <div className="flex items-center gap-4">
+        <div className="h-14 w-14 shrink-0 overflow-hidden rounded-full bg-zinc-200">
+          <Image
+            src={avatarUrl}
+            alt={author}
+            width={56}
+            height={56}
+            className="h-full w-full object-cover"
+            unoptimized
+          />
+        </div>
+
+        <figcaption className="flex flex-col">
+          <span className="font-medium leading-tight">{author}</span>
+          {role && <span className="text-sm text-zinc-500">{role}</span>}
+        </figcaption>
+      </div>
+
+      <blockquote className="mt-4 text-zinc-700 dark:text-zinc-200">
+        <p>“{quote}”</p>
+      </blockquote>
+
+      {href && (
+        <Link
+          href={href}
+          className="mt-4 inline-block text-sm underline decoration-dotted underline-offset-4 text-zinc-600 hover:text-zinc-900"
+        >
+          View full case study →
+        </Link>
+      )}
+    </figure>
+  );
+}

--- a/components/Testimonials.tsx
+++ b/components/Testimonials.tsx
@@ -1,0 +1,41 @@
+import TestimonialCard, { Testimonial } from "@/components/TestimonialCard";
+import { createInitialsAvatar } from "@/lib/avatar";
+
+const testimonials: Testimonial[] = [
+  {
+    quote: "Icarius brought clarity and pace to a complex HCM migration.",
+    author: "CIO, FTSE250",
+    role: "Global HR transformation lead",
+    href: "/case-studies/hcm-migration",
+    avatarSrc: createInitialsAvatar("CIO FTSE250"),
+  },
+  {
+    quote: "The audit sprint gave us a pragmatic backlog we actually shipped.",
+    author: "HR Director, Retail",
+    role: "National retail group",
+    href: "/case-studies/retail-audit-sprint",
+    avatarSrc: createInitialsAvatar("HR Director Retail"),
+  },
+  {
+    quote: "Our HR Ops assistant cut average handle time dramatically.",
+    author: "Shared Services Lead",
+    role: "Global HR operations",
+    href: "/case-studies/hr-ops-assistant",
+    avatarSrc: createInitialsAvatar("Shared Services Lead"),
+  },
+];
+
+export default function Testimonials() {
+  return (
+    <section aria-labelledby="what-clients-say" className="mx-auto max-w-5xl px-4">
+      <h2 id="what-clients-say" className="mb-4 text-2xl font-semibold">
+        What clients say
+      </h2>
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {testimonials.map((testimonial) => (
+          <TestimonialCard key={testimonial.href ?? testimonial.author} {...testimonial} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/lib/avatar.ts
+++ b/lib/avatar.ts
@@ -1,0 +1,57 @@
+const gradientPalette: ReadonlyArray<[string, string]> = [
+  ["#6366f1", "#a855f7"],
+  ["#0ea5e9", "#22d3ee"],
+  ["#f97316", "#facc15"],
+  ["#22c55e", "#14b8a6"],
+  ["#ec4899", "#f472b6"],
+];
+
+const sanitizeWords = (value: string) =>
+  value
+    .replace(/[^A-Za-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter(Boolean);
+
+const initialsFromName = (name: string) => {
+  const words = sanitizeWords(name);
+  if (words.length === 0) {
+    return "•";
+  }
+
+  if (words.length === 1) {
+    const [word] = words;
+    return word.slice(0, 2).toUpperCase().padEnd(2, word[0]?.toUpperCase() ?? "•");
+  }
+
+  const first = words[0][0] ?? "";
+  const last = words[words.length - 1][0] ?? "";
+  const initials = `${first}${last}`.trim();
+  return initials ? initials.toUpperCase() : "•";
+};
+
+const hashSeed = (seed: string) => {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i += 1) {
+    hash = (hash << 5) - hash + seed.charCodeAt(i);
+    hash |= 0; // Convert to 32bit integer
+  }
+  return Math.abs(hash);
+};
+
+export type AvatarOptions = {
+  initials?: string;
+  palette?: [string, string];
+};
+
+export const createInitialsAvatar = (seed: string, options: AvatarOptions = {}) => {
+  const initials = (options.initials ?? initialsFromName(seed)).slice(0, 2) || "•";
+  const paletteIndex = hashSeed(seed) % gradientPalette.length;
+  const [from, to] = options.palette ?? gradientPalette[paletteIndex];
+  const gradientId = `g${hashSeed(`${seed}-${from}-${to}`) % 1_000_000}`;
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-label="${initials}">\n  <defs>\n    <linearGradient id="${gradientId}" x1="0%" y1="0%" x2="100%" y2="100%">\n      <stop offset="0%" stop-color="${from}" />\n      <stop offset="100%" stop-color="${to}" />\n    </linearGradient>\n  </defs>\n  <rect width="96" height="96" rx="48" fill="url(#${gradientId})" />\n  <text x="50%" y="52%" text-anchor="middle" dominant-baseline="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="34" font-weight="600" fill="white">${initials}</text>\n</svg>`;
+
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+};
+
+export const getInitials = (name: string) => initialsFromName(name);


### PR DESCRIPTION
## Summary
- export the testimonial shape and render card links with Next.js Link to keep navigation client-side
- tighten the testimonials data with explicit roles and stable keys while keeping the grid styling intact
- replace binary avatar assets with generated SVG data URIs to keep PRs text-only and ensure consistent presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5a57f305083309756dc5227f757b9