### PR TITLE
Fix analytics dataLayer type mismatch

### DIFF
--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -4,7 +4,7 @@ import { hasAnalyticsConsent } from "@/app/consent/ConsentBanner";
 
 declare global {
   interface Window {
-    dataLayer?: Array<Record<string, unknown>>;
+    dataLayer?: unknown[];
     gtag?: (...args: unknown[]) => void;
   }
 }
@@ -28,7 +28,8 @@ export const track = (eventName: TrackEventName, payload: TrackEventPayload = {}
     window.dataLayer = [];
   }
 
-  window.dataLayer.push(eventPayload);
+  const dataLayer = window.dataLayer as Array<Record<string, unknown>>;
+  dataLayer.push(eventPayload);
 
   const gtag = window.gtag;
   if (typeof gtag === "function") {


### PR DESCRIPTION
## Summary
- align the global Window dataLayer type with the default Next.js definition to prevent type conflicts
- keep pushing structured analytics events by casting the runtime dataLayer array

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5afa3ab60833084e873b1dcd30269