### PR TITLE
Add testimonial link CI guard and regression test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
-    "analyze": "ANALYZE=true npm run build"
+    "analyze": "ANALYZE=true npm run build",
+    "prebuild": "tsx scripts/validate-internal-links.ts"
   },
   "engines": {
     "node": "22.x"
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^15.5.4",
+    "@playwright/test": "^1.49.1",
     "@tailwindcss/typography": "^0.5.15",
     "@types/node": "^20.14.9",
     "@types/react": "^18.2.37",
@@ -39,6 +41,7 @@
     "eslint-config-next": "14.2.5",
     "postcss": "^8.4.41",
     "tailwindcss": "^3.4.13",
+    "tsx": "^4.16.0",
     "typescript": "^5.6.2",
     "vitest": "^3.2.4"
   }

--- a/scripts/validate-internal-links.ts
+++ b/scripts/validate-internal-links.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const appDir = path.join(root, "app");
+
+// Mirror the testimonial hrefs here (source of truth for CI)
+const testimonialLinks = [
+  "/case-studies/hcm-migration",
+  "/case-studies/retail-audit-sprint",
+  "/case-studies/hr-ops-assistant",
+];
+
+const missing: string[] = [];
+
+for (const href of testimonialLinks) {
+  const parts = href.replace(/^\//, "").split("/");
+  const pagePathTSX = path.join(appDir, ...parts, "page.tsx");
+  const pagePathJSX = path.join(appDir, ...parts, "page.jsx");
+  if (!fs.existsSync(pagePathTSX) && !fs.existsSync(pagePathJSX)) {
+    missing.push(href);
+  }
+}
+
+if (missing.length) {
+  console.error(
+    "Broken internal testimonial links (no page.tsx found):",
+    missing.join(", ")
+  );
+  process.exit(1);
+} else {
+  console.log("All testimonial links resolve to pages.");
+}

--- a/tests/testimonials.spec.ts
+++ b/tests/testimonials.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "@playwright/test";
+
+const links = [
+  "/case-studies/hcm-migration",
+  "/case-studies/retail-audit-sprint",
+  "/case-studies/hr-ops-assistant",
+];
+
+test("testimonial links navigate and render an H1", async ({ page }) => {
+  await page.goto("/");
+  for (const href of links) {
+    const link = page.locator(`a[href="${href}"]`).first();
+    if (await link.count()) {
+      const [nav] = await Promise.all([
+        page.waitForNavigation(),
+        link.click(),
+      ]);
+      expect(nav?.ok()).toBeTruthy();
+      await expect(page.locator("h1")).toBeVisible();
+      await page.goBack();
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add a prebuild CI guard that ensures testimonial links resolve to app pages
- add a lightweight Playwright regression that navigates testimonial links and checks for an H1
- include supporting tooling dependencies for the validation script and test

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5b857ccb883308328976a7718e7d2