### PR TITLE
Add case study data, dynamic avatars, and sitemap automation

### DIFF
--- a/app/case-studies/[slug]/page.tsx
+++ b/app/case-studies/[slug]/page.tsx
@@ -1,65 +1,23 @@
-import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-
-const CASE_STUDIES = {
-  "hcm-migration": {
-    title: "HCM Migration",
-    summary:
-      "Discover how Icarius guided a global enterprise through a seamless human capital management migration.",
-  },
-  "retail-audit-sprint": {
-    title: "Retail Audit Sprint",
-    summary:
-      "Explore the rapid discovery sprint that helped a retail leader uncover critical gaps in store operations.",
-  },
-  "hr-ops-assistant": {
-    title: "HR Ops Assistant",
-    summary:
-      "See how an intelligent assistant empowered HR teams to streamline everyday workflows.",
-  },
-} as const;
-
-type CaseStudySlug = keyof typeof CASE_STUDIES;
+import type { Metadata } from "next";
+import { CASE_STUDIES, type CaseStudySlug } from "@/data/caseStudies";
 
 export function generateStaticParams() {
   return Object.keys(CASE_STUDIES).map((slug) => ({ slug }));
 }
 
-export function generateMetadata({
-  params,
-}: {
-  params: { slug: string };
-}): Metadata {
+export function generateMetadata({ params }: { params: { slug: string } }): Metadata {
   const data = CASE_STUDIES[params.slug as CaseStudySlug];
-  if (!data) {
-    return {};
-  }
-
-  return {
-    title: `${data.title} Case Study | Icarius Consulting`,
-    description: data.summary,
-  };
+  return data ? { title: `${data.title} – Case Study | Icarius Consulting` } : {};
 }
 
-export default function CaseStudyPage({
-  params,
-}: {
-  params: { slug: string };
-}) {
+export default function Page({ params }: { params: { slug: string } }) {
   const data = CASE_STUDIES[params.slug as CaseStudySlug];
-
-  if (!data) {
-    return notFound();
-  }
-
+  if (!data) return notFound();
   return (
-    <main className="prose mx-auto max-w-3xl px-6 py-16">
+    <main className="prose p-8">
       <h1>{data.title}</h1>
-      <p>{data.summary}</p>
-      <p className="text-sm text-muted-foreground">
-        Full case study content is on the way. Check back soon for detailed results
-        and insights.
-      </p>
+      <p>{data.excerpt}</p>
     </main>
   );
 }

--- a/app/img/testimonials/[name]/route.ts
+++ b/app/img/testimonials/[name]/route.ts
@@ -1,0 +1,42 @@
+const COLORS = ["#EEF2FF", "#ECFEFF", "#ECFDF5", "#FEF3C7", "#FCE7F3", "#F3E8FF", "#E5E7EB"];
+const TEXT = "#111827";
+
+function hash(str: string) {
+  let h = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    h = (h << 5) - h + str.charCodeAt(i);
+    h |= 0;
+  }
+  return Math.abs(h);
+}
+
+function initials(name: string) {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((s) => s[0]!.toUpperCase())
+    .join("");
+}
+
+export async function GET(_: Request, { params }: { params: { name: string } }) {
+  const name = decodeURIComponent(params.name || "User");
+  const bg = COLORS[hash(name) % COLORS.length];
+  const text = initials(name) || "U";
+  const svg = `
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96">
+  <defs><clipPath id="r"><rect x="0" y="0" width="96" height="96" rx="48"/></clipPath></defs>
+  <rect width="96" height="96" fill="${bg}" rx="48"/>
+  <g clip-path="url(#r)">
+    <text x="50%" y="54%" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial"
+          font-size="36" font-weight="700" fill="${TEXT}" text-anchor="middle" dominant-baseline="middle">${text}</text>
+  </g>
+</svg>`.trim();
+
+  return new Response(svg, {
+    headers: {
+      "Content-Type": "image/svg+xml",
+      "Cache-Control": "public, max-age=31536000, immutable",
+    },
+  });
+}

--- a/components/Testimonials.tsx
+++ b/components/Testimonials.tsx
@@ -1,5 +1,5 @@
 import TestimonialCard, { Testimonial } from "@/components/TestimonialCard";
-import { createInitialsAvatar } from "@/lib/avatar";
+import { CASE_STUDIES } from "@/data/caseStudies";
 
 const testimonials: Testimonial[] = [
   {
@@ -7,37 +7,43 @@ const testimonials: Testimonial[] = [
     author: "CIO, FTSE250",
     role: "Global HR transformation lead",
     href: "/case-studies/hcm-migration",
-    avatarSrc: createInitialsAvatar("CIO FTSE250"),
+    avatarSrc: "/img/testimonials/cio-ftse250",
   },
   {
     quote: "The audit sprint gave us a pragmatic backlog we actually shipped.",
     author: "HR Director, Retail",
     role: "National retail group",
     href: "/case-studies/retail-audit-sprint",
-    avatarSrc: createInitialsAvatar("HR Director Retail"),
+    avatarSrc: "/img/testimonials/hr-director-retail",
   },
   {
     quote: "Our HR Ops assistant cut average handle time dramatically.",
     author: "Shared Services Lead",
     role: "Global HR operations",
     href: "/case-studies/hr-ops-assistant",
-    avatarSrc: createInitialsAvatar("Shared Services Lead"),
+    avatarSrc: "/img/testimonials/shared-services-lead",
   },
 ];
 
 export default function Testimonials() {
+  if (process.env.NODE_ENV !== "production") {
+    for (const t of testimonials) {
+      const slug = t.href?.split("/").pop() ?? "";
+      if (!(slug in CASE_STUDIES)) {
+        // eslint-disable-next-line no-console
+        console.warn(`[Testimonials] Unknown case study slug in href: ${t.href}`);
+      }
+    }
+  }
+
   return (
     <section aria-labelledby="what-clients-say" className="mx-auto max-w-5xl px-4">
-      <h2 id="what-clients-say" className="text-2xl font-semibold mb-4">
-        What clients say
-      </h2>
-      <ul role="list" className="grid list-none gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {testimonials.map((testimonial) => (
-          <li key={testimonial.href ?? testimonial.author} className="h-full">
-            <TestimonialCard {...testimonial} />
-          </li>
+      <h2 id="what-clients-say" className="text-2xl font-semibold mb-4">What clients say</h2>
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {testimonials.map((t) => (
+          <TestimonialCard key={t.href ?? t.author} {...t} />
         ))}
-      </ul>
+      </div>
     </section>
   );
 }

--- a/data/caseStudies.ts
+++ b/data/caseStudies.ts
@@ -1,0 +1,20 @@
+export const CASE_STUDIES = {
+  "hcm-migration": {
+    title: "Global HCM migration",
+    excerpt:
+      "How Icarius unified regional HR stacks and delivered a roadmap for a single global HCM platform.",
+  },
+  "retail-audit-sprint": {
+    title: "Retail audit sprint",
+    excerpt:
+      "A four-week discovery that prioritised the fixes a national retailer needed to stabilise store operations.",
+  },
+  "hr-ops-assistant": {
+    title: "HR operations AI assistant",
+    excerpt:
+      "The guardrails and knowledge refresh that helped an HR shared services team cut average handle time.",
+  },
+} as const;
+
+export type CaseStudies = typeof CASE_STUDIES;
+export type CaseStudySlug = keyof CaseStudies;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "test": "vitest run",
     "analyze": "ANALYZE=true npm run build",
-    "prebuild": "tsx scripts/validate-internal-links.ts"
+    "prebuild": "tsx scripts/validate-internal-links.ts && tsx scripts/generate-sitemap.ts"
   },
   "engines": {
     "node": "22.x"

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+  <url>
+    <loc>https://www.icarius-consulting.com/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://www.icarius-consulting.com/about</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.icarius-consulting.com/contact</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.icarius-consulting.com/services</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.icarius-consulting.com/case-studies</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.icarius-consulting.com/case-studies/hcm-migration</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.icarius-consulting.com/case-studies/retail-audit-sprint</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.icarius-consulting.com/case-studies/hr-ops-assistant</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -1,0 +1,28 @@
+import fs from "node:fs";
+import path from "node:path";
+import { CASE_STUDIES } from "@/data/caseStudies";
+
+const BASE_URL = "https://www.icarius-consulting.com";
+
+const staticPaths = ["/", "/about", "/contact", "/services", "/case-studies"];
+const caseStudyPaths = Object.keys(CASE_STUDIES).map((slug) => `/case-studies/${slug}`);
+const allPaths = [...staticPaths, ...caseStudyPaths];
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${allPaths
+  .map(
+    (p) => `
+  <url>
+    <loc>${BASE_URL}${p}</loc>
+    <changefreq>monthly</changefreq>
+    <priority>${p === "/" ? "1.0" : "0.8"}</priority>
+  </url>`
+  )
+  .join("")}
+</urlset>`.trim();
+
+const outPath = path.join(process.cwd(), "public", "sitemap.xml");
+fs.mkdirSync(path.dirname(outPath), { recursive: true });
+fs.writeFileSync(outPath, `${xml}\n`);
+console.log("✅ sitemap.xml written:", outPath);

--- a/tests/testimonials.spec.ts
+++ b/tests/testimonials.spec.ts
@@ -6,15 +6,12 @@ const links = [
   "/case-studies/hr-ops-assistant",
 ];
 
-test("testimonial links navigate and render an H1", async ({ page }) => {
+test("testimonial links open case study pages", async ({ page }) => {
   await page.goto("/");
   for (const href of links) {
     const link = page.locator(`a[href="${href}"]`).first();
     if (await link.count()) {
-      const [nav] = await Promise.all([
-        page.waitForNavigation(),
-        link.click(),
-      ]);
+      const [nav] = await Promise.all([page.waitForNavigation(), link.click()]);
       expect(nav?.ok()).toBeTruthy();
       await expect(page.locator("h1")).toBeVisible();
       await page.goBack();

--- a/vercel.json
+++ b/vercel.json
@@ -31,6 +31,12 @@
   ],
   "redirects": [
     {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "ww.icarius-consulting.com" }],
+      "destination": "https://www.icarius-consulting.com/:path*",
+      "permanent": true
+    },
+    {
       "source": "/index.html",
       "destination": "/",
       "permanent": true

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
+    include: ['**/*.test.{ts,tsx}'],
+    exclude: ['node_modules/**', 'tests/**/*.spec.ts'],
   },
 });


### PR DESCRIPTION
## Summary
- source case study pages, testimonials, and scripts from a shared CASE_STUDIES map
- serve cached SVG testimonial avatars and guard internal links with build-time validation
- generate sitemap.xml during prebuild and add host redirect coverage

## Testing
- npm run prebuild
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e63e44ba608330bba0eff90de666e1